### PR TITLE
Clean up repo and rewrite documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,18 @@
 docs/source
 .worktrees/
+.DS_Store
+
+# Demo artifacts (not part of the library)
+demo.py
+create_demo_animation.py
+create_preview.py
+record_demo.sh
+DEMO_README.md
+hyper_surrogate_demo.*
+
+# Fortran build artifacts
+scripts/
+examples/outputs/
 
 # From https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore
 

--- a/README.md
+++ b/README.md
@@ -3,18 +3,53 @@
 [![Release](https://img.shields.io/github/v/release/jpsferreira/hyper-surrogate)](https://img.shields.io/github/v/release/jpsferreira/hyper-surrogate)
 [![Build status](https://img.shields.io/github/actions/workflow/status/jpsferreira/hyper-surrogate/main.yml?branch=main)](https://github.com/jpsferreira/hyper-surrogate/actions/workflows/main.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/jpsferreira/hyper-surrogate/branch/main/graph/badge.svg)](https://codecov.io/gh/jpsferreira/hyper-surrogate)
-[![Commit activity](https://img.shields.io/github/commit-activity/m/jpsferreira/hyper-surrogate)](https://img.shields.io/github/commit-activity/m/jpsferreira/hyper-surrogate)
 [![License](https://img.shields.io/github/license/jpsferreira/hyper-surrogate)](https://img.shields.io/github/license/jpsferreira/hyper-surrogate)
 
-Hyperelastic Surrogates
+Data-driven surrogates for hyperelastic constitutive models in finite element analysis.
 
 - **Github repository**: <https://github.com/jpsferreira/hyper-surrogate/>
-- **Documentation** <https://jpsferreira.github.io/hyper-surrogate/>
+- **Documentation**: <https://jpsferreira.github.io/hyper-surrogate/>
+
+## Features
+
+- **Symbolic mechanics** -- Automatic PK2 stress and stiffness tensor derivation via SymPy
+- **ML surrogates** -- MLP and Input-Convex Neural Network (ICNN) models for constitutive response approximation
+- **Fortran export** -- Transpile trained models to standalone Fortran 90 subroutines with baked-in weights
+- **Analytical UMAT** -- Generate optimized Fortran UMAT subroutines from symbolic expressions
+
+## Quick start
+
+```python
+import hyper_surrogate as hs
+
+# Define material and generate training data
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material, n_samples=5000, input_type="invariants", target_type="pk2_voigt",
+)
+
+# Train an MLP surrogate
+model = hs.MLP(input_dim=3, output_dim=6, hidden_dims=[32, 32], activation="tanh")
+result = hs.Trainer(model, train_ds, val_ds, loss_fn=hs.StressLoss(), max_epochs=500).fit()
+
+# Export to Fortran 90
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+hs.FortranEmitter(exported).write("nn_surrogate.f90")
+```
+
+See the [examples](https://jpsferreira.github.io/hyper-surrogate/examples/) for more usage patterns.
 
 ## Installation
 
-- Read the [installation guide](https://jpsferreira.github.io/hyper-surrogate/installation.html) for more information.
+```bash
+pip install hyper-surrogate        # core (NumPy, SymPy)
+pip install hyper-surrogate[ml]    # with PyTorch for ML surrogates
+```
 
-## Usage
+From source with [uv](https://docs.astral.sh/uv/):
 
-jpsferreira
+```bash
+git clone https://github.com/jpsferreira/hyper-surrogate.git
+cd hyper-surrogate
+uv sync --all-groups --extra ml
+```

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,26 @@
+# About
+
+**hyper-surrogate** is a Python library for building data-driven surrogates of hyperelastic constitutive models used in finite element analysis.
+
+## Motivation
+
+Hyperelastic material models (Neo-Hookean, Mooney-Rivlin, etc.) define stress-strain relationships through strain energy functions. Evaluating these symbolically at every integration point is expensive. This library provides:
+
+1. **Symbolic mechanics** -- SymPy-based strain energy differentiation to derive PK2 stress and material stiffness tensors automatically.
+2. **ML surrogates** -- Train neural networks (MLP, Input-Convex Neural Networks) to approximate the constitutive response, orders of magnitude faster than symbolic evaluation.
+3. **Fortran export** -- Transpile trained models into standalone Fortran 90 subroutines (UMAT-compatible) with baked-in weights, ready for commercial FE solvers (Abaqus, LS-DYNA, etc.).
+
+## Architecture
+
+The library is organized into layered subpackages:
+
+- `mechanics` -- Symbolic tensor algebra, kinematics, and material model definitions
+- `data` -- Deformation gradient generation and dataset creation for training
+- `models` -- Neural network architectures (MLP, ICNN) with export support
+- `training` -- Loss functions (stress, energy-stress) and training loop
+- `export` -- Weight extraction, Fortran code generation, and analytical UMAT generation
+- `reporting` -- Visualization and statistics for deformation data
+
+## License
+
+See the [LICENSE](https://github.com/jpsferreira/hyper-surrogate/blob/main/LICENSE) file.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,140 @@
+# Examples
+
+## Quick start: Evaluate stress for a Neo-Hookean material
+
+```python
+import numpy as np
+import hyper_surrogate as hs
+
+# Define a Neo-Hookean material
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+
+# Generate uniaxial deformation gradients
+gen = hs.DeformationGenerator(seed=42)
+F = gen.uniaxial(n=10)
+
+# Compute the right Cauchy-Green tensor
+C = hs.Kinematics.right_cauchy_green(F)
+
+# Evaluate PK2 stress (N, 3, 3) and strain energy (N,)
+pk2 = material.evaluate_pk2(C)
+energy = material.evaluate_energy(C)
+
+print(f"PK2 stress shape: {pk2.shape}")
+print(f"Energy shape: {energy.shape}")
+```
+
+## Generate an analytical Fortran UMAT
+
+Generate a Fortran 90 subroutine for a Neo-Hookean material with common subexpression elimination:
+
+```python
+from hyper_surrogate.mechanics.materials import NeoHooke
+from hyper_surrogate.export.fortran.analytical import UMATHandler
+
+material = NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+handler = UMATHandler(material)
+handler.generate("neohooke_umat.f")
+```
+
+This writes a complete UMAT subroutine with Cauchy stress and spatial tangent stiffness, ready for use in Abaqus or LS-DYNA.
+
+## Train an MLP surrogate and export to Fortran
+
+Full pipeline: generate data, train a neural network, and export to a standalone Fortran 90 module.
+
+```python
+import hyper_surrogate as hs
+
+# 1. Define material and generate training data
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material,
+    n_samples=5000,
+    input_type="invariants",   # 3 inputs: I1_bar, I2_bar, J
+    target_type="pk2_voigt",   # 6 outputs: PK2 stress in Voigt notation
+)
+
+# 2. Build and train the model
+model = hs.MLP(input_dim=3, output_dim=6, hidden_dims=[32, 32], activation="tanh")
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.StressLoss(),
+    max_epochs=500,
+    lr=1e-3,
+).fit()
+
+print(f"Best validation loss: {result.best_val_loss:.6f} (epoch {result.best_epoch})")
+
+# 3. Export weights and generate Fortran
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+exported.save("mlp_surrogate.npz")
+
+emitter = hs.FortranEmitter(exported)
+emitter.write("nn_surrogate.f90")
+```
+
+The generated `nn_surrogate.f90` contains a self-contained Fortran 90 module with all weights baked in as `PARAMETER` arrays and `MATMUL`-based forward pass -- no external dependencies.
+
+## Train an energy-based ICNN surrogate
+
+Input-Convex Neural Networks (ICNN) guarantee convexity of the predicted strain energy, ensuring thermodynamic consistency.
+
+```python
+import hyper_surrogate as hs
+
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+
+# Energy target: the dataset stores (energy, dW/d_invariants) as a tuple
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material,
+    n_samples=5000,
+    input_type="invariants",
+    target_type="energy",
+)
+
+# ICNN outputs a scalar (energy) -- stress is enforced via autograd in the loss
+model = hs.ICNN(input_dim=3, hidden_dims=[32, 32])
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=500,
+).fit()
+
+# Export
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+exported.save("icnn_surrogate.npz")
+```
+
+## Kinematics utilities
+
+Batch-compute common continuum mechanics quantities:
+
+```python
+import numpy as np
+import hyper_surrogate as hs
+
+gen = hs.DeformationGenerator(seed=0)
+F = gen.combined(n=100)  # Mix of uniaxial, biaxial, shear modes
+
+C = hs.Kinematics.right_cauchy_green(F)      # (100, 3, 3)
+B = hs.Kinematics.left_cauchy_green(F)       # (100, 3, 3)
+J = hs.Kinematics.jacobian(F)               # (100,)
+I1 = hs.Kinematics.isochoric_invariant1(C)  # (100,)
+I2 = hs.Kinematics.isochoric_invariant2(C)  # (100,)
+
+stretches = hs.Kinematics.principal_stretches(C)  # (100, 3)
+```
+
+## Reporting
+
+Visualize deformation data:
+
+```python
+from hyper_surrogate.reporting.reporter import Reporter
+
+reporter = Reporter(C)  # (N, 3, 3) tensor batch
+reporter.fig_eigenvalues()
+reporter.fig_determinants()
+reporter.generate_report("report/")
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,53 +2,43 @@
 
 ## From source
 
-- Clone the repository
+Clone the repository:
 
-```zsh
+```bash
 git clone https://github.com/jpsferreira/hyper-surrogate.git
 cd hyper-surrogate
 ```
 
-- Install dependencies
+Install dependencies with [uv](https://docs.astral.sh/uv/):
 
-```zsh
-poetry install
+```bash
+uv sync --all-groups
 ```
 
-or
+To also install the ML extras (PyTorch):
 
-```zsh
-uv install
+```bash
+uv sync --all-groups --extra ml
 ```
 
-- Load python environment
+Run tests:
 
-```zsh
-poetry shell
-```
-
-or
-
-```zsh
-source .venv/bin/activate
-```
-
-- Run tests
-
-```zsh
-pytest
+```bash
+uv run pytest
 ```
 
 ## From PyPI
 
-```zsh
+```bash
 pip install hyper-surrogate
 ```
 
-```zsh
-poetry add hyper-surrogate
+```bash
+uv add hyper-surrogate
 ```
 
-```zsh
-uv add hyper-surrogate
+With ML support:
+
+```bash
+pip install hyper-surrogate[ml]
 ```

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,33 @@
+# API Reference
+
+## Mechanics
+
 ::: hyper_surrogate.mechanics.symbolic
 ::: hyper_surrogate.mechanics.kinematics
 ::: hyper_surrogate.mechanics.materials
+
+## Data
+
 ::: hyper_surrogate.data.deformation
 ::: hyper_surrogate.data.dataset
+
+## Models
+
+::: hyper_surrogate.models.base
+::: hyper_surrogate.models.mlp
+::: hyper_surrogate.models.icnn
+
+## Training
+
+::: hyper_surrogate.training.losses
+::: hyper_surrogate.training.trainer
+
+## Export
+
+::: hyper_surrogate.export.weights
+::: hyper_surrogate.export.fortran.emitter
+::: hyper_surrogate.export.fortran.analytical
+
+## Reporting
+
 ::: hyper_surrogate.reporting.reporter

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,12 +5,14 @@ site_description: Hyperelastic Surrogates
 site_author: Joao Ferreira
 edit_uri: edit/main/docs/
 repo_name: jpsferreira/hyper-surrogate
-copyright: Maintained by <a href="https://jpsferreira.com">Florian</a>.
+copyright: Maintained by <a href="https://github.com/jpsferreira">Joao Ferreira</a>.
 
 nav:
   - Home: index.md
   - Installation: installation.md
-  - Modules: modules.md
+  - Examples: examples.md
+  - API Reference: modules.md
+  - About: about.md
 plugins:
   - search
   - mkdocstrings:

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,0 @@
-[virtualenvs]
-in-project = true


### PR DESCRIPTION
## Summary
- Remove stale Poetry artifacts (`poetry.toml`) and update `.gitignore`
- Rewrite README with features, quick start example, and uv installation
- Rewrite docs: installation (uv), about (motivation/architecture), examples (6 happy paths)
- Add all 14 modules to API reference (was missing 8 after the architecture refactor)
- Fix mkdocs.yml copyright and nav structure

## Test plan
- [ ] `make docs-test` builds without errors
- [ ] `make check` passes (lint, mypy, deptry)
- [ ] Examples page renders correctly on docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)