### PR TITLE
Community polish: docs, CLAUDE.md, examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# hyper-surrogate
+
+Data-driven surrogates for hyperelastic constitutive models in finite element analysis.
+
+## Tech Stack
+
+- **Python 3.12+** with `from __future__ import annotations` everywhere
+- **uv** for dependency management (`uv sync --all-groups --extra ml`)
+- **ruff** for linting/formatting (120-char line length)
+- **mypy** in strict mode on `hyper_surrogate/`
+- **pytest** for testing (`@pytest.mark.slow` for expensive tests)
+- **mkdocs-material** for documentation
+
+## Key Commands
+
+```bash
+make install    # Create venv and install pre-commit hooks
+make check      # Run ruff, mypy, deptry
+make test       # Run pytest with coverage (excludes slow tests)
+make docs       # Build and serve docs locally
+make docs-test  # Verify docs build without errors
+```
+
+## Architecture
+
+```
+Material -> DeformationGenerator -> Dataset -> MLP/ICNN -> FortranEmitter -> .f90
+```
+
+### Core (always available — NumPy, SymPy)
+
+- `mechanics/` — `SymbolicHandler` (tensor algebra), `Kinematics` (batch operations), `Material` ABC + `NeoHooke`, `MooneyRivlin`
+- `data/` — `DeformationGenerator` (deformation gradients), `create_datasets`, `Normalizer`
+- `reporting/` — `Reporter` for deformation statistics and PDF reports
+
+### ML (requires `torch`)
+
+- `models/` — `SurrogateModel` ABC, `MLP`, `ICNN`
+- `training/` — `Trainer`, `EnergyStressLoss`, `StressLoss`, `StressTangentLoss`
+
+### Export (requires `torch`)
+
+- `export/weights.py` — `ExportedModel`, `extract_weights`
+- `export/fortran/emitter.py` — `FortranEmitter` (standalone NN → Fortran 90)
+- `export/fortran/hybrid.py` — `HybridUMATEmitter` (NN SEF + analytical mechanics → UMAT)
+- `export/fortran/analytical.py` — `UMATHandler` (symbolic → Fortran UMAT via SymPy CSE)
+
+## Conventions
+
+- **Torch optional:** ML imports wrapped in `try/except ImportError` in `__init__.py`
+- **Model interface:** All models extend `SurrogateModel` ABC (`forward`, `layer_sequence`, `export_weights`)
+- **Export interface:** `ExportedModel` flat dataclass with layers, weights, normalizers, metadata
+- **Fortran layout:** Column-major arrays, 15-digit double precision (`:.15e`), `MATMUL`-based forward pass
+
+## Branch Prefixes
+
+- `feat/` — new features
+- `fix/` — bug fixes
+- `chore/` — maintenance and cleanup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Anything tagged with "enhancement" and "help wanted" is open to whoever wants to
 
 ## Write Documentation
 
-Cookiecutter PyPackage could always use more documentation, whether as part of the official docs, in docstrings, or even on the web in blog posts, articles, and such.
+hyper-surrogate could always use more documentation, whether as part of the official docs, in docstrings, or even on the web in blog posts, articles, and such.
 
 ## Submit Feedback
 
@@ -45,7 +45,7 @@ If you are proposing a new feature:
 # Get Started!
 
 Ready to contribute? Here's how to set up `hyper-surrogate` for local development.
-Please note this documentation assumes you already have `poetry` and `Git` installed and ready to go.
+Please note this documentation assumes you already have [uv](https://docs.astral.sh/uv/) and `Git` installed and ready to go.
 
 1. Fork the `hyper-surrogate` repo on GitHub.
 
@@ -68,17 +68,16 @@ If you are using `pyenv`, select a version to use locally. (See installed versio
 pyenv local <x.y.z>
 ```
 
-Then, install and activate the environment with:
+Then, install the environment with all development dependencies:
 
 ```bash
-poetry install
-poetry shell
+uv sync --all-groups --extra ml
 ```
 
 4. Install pre-commit to run linters/formatters at commit time:
 
 ```bash
-poetry run pre-commit install
+uv run pre-commit install
 ```
 
 5. Create a branch for local development:
@@ -86,6 +85,8 @@ poetry run pre-commit install
 ```bash
 git checkout -b name-of-your-bugfix-or-feature
 ```
+
+Branch prefixes: `feat/` for features, `fix/` for bug fixes, `chore/` for maintenance.
 
 Now you can make your changes locally.
 
@@ -103,17 +104,26 @@ Now, validate that all unit tests are passing:
 make test
 ```
 
-9. Before raising a pull request you should also run tox.
-   This will run the tests across different versions of Python:
+To run only fast tests (skipping slow ones):
 
 ```bash
-tox
+uv run pytest -m "not slow"
 ```
 
-This requires you to have multiple versions of python installed.
-This step is also triggered in the CI/CD pipeline, so you could also choose to skip this step locally.
+To run slow tests explicitly:
 
-10. Commit your changes and push your branch to GitHub:
+```bash
+uv run pytest -m slow
+```
+
+8. Build and verify the documentation:
+
+```bash
+make docs-test   # check docs build without errors
+make docs         # serve docs locally at http://127.0.0.1:8000
+```
+
+9. Commit your changes and push your branch to GitHub:
 
 ```bash
 git add .
@@ -121,7 +131,16 @@ git commit -m "Your detailed description of your changes."
 git push origin name-of-your-bugfix-or-feature
 ```
 
-11. Submit a pull request through the GitHub website.
+10. Submit a pull request through the GitHub website.
+
+# Code Style
+
+- **Formatter/linter:** [ruff](https://docs.astral.sh/ruff/) with 120-character line length
+- **Type checking:** [mypy](https://mypy-lang.org/) in strict mode on `hyper_surrogate/`
+- **Imports:** Use `from __future__ import annotations` in all modules
+- **Testing:** [pytest](https://pytest.org/) with `@pytest.mark.slow` for expensive tests
+
+All checks run via `make check` (ruff, mypy, deptry) and `make test` (pytest with coverage).
 
 # Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,53 @@ Data-driven surrogates for hyperelastic constitutive models in finite element an
 - **Github repository**: <https://github.com/jpsferreira/hyper-surrogate/>
 - **Documentation**: <https://jpsferreira.github.io/hyper-surrogate/>
 
+## Table of Contents
+
+- [Why hyper-surrogate?](#why-hyper-surrogate)
+- [Architecture](#architecture)
+- [Features](#features)
+- [Quick Start](#quick-start)
+- [Installation](#installation)
+- [Examples](#examples)
+- [Contributing](#contributing)
+
+## Why hyper-surrogate?
+
+Finite element solvers need constitutive models (stress-strain relationships) to simulate materials. Writing and maintaining these models — especially user-defined material subroutines (UMATs) for Abaqus/LS-DYNA — is tedious, error-prone, and tightly coupled to the solver.
+
+**hyper-surrogate** provides an end-to-end pipeline that:
+
+1. **Generates training data** from symbolic material definitions (NeoHooke, Mooney-Rivlin, etc.)
+2. **Trains neural network surrogates** (MLP or Input-Convex NN) that learn the strain energy function
+3. **Exports to standalone Fortran 90** with baked-in weights — no Python or external dependencies at runtime
+
+This gives you **solver portability** (one training, any Fortran-capable solver), **thermodynamic consistency** (energy-based formulation with automatic stress/tangent derivation), and **speed** (the exported Fortran is a pure forward pass).
+
+## Architecture
+
+```
+Material ─> DeformationGenerator ─> Dataset ─> MLP / ICNN ─> FortranEmitter ─> .f90
+   │                                              │
+   │         (symbolic SEF)                        │  (trained NN weights)
+   │                                              │
+   └──── UMATHandler ─────────────────────────────┘
+         (analytical Fortran via SymPy CSE)     HybridUMATEmitter
+                                                (NN SEF + analytical mechanics)
+```
+
 ## Features
 
 - **Symbolic mechanics** -- Automatic PK2 stress and stiffness tensor derivation via SymPy
 - **ML surrogates** -- MLP and Input-Convex Neural Network (ICNN) models for constitutive response approximation
+- **Hybrid UMAT** -- NN-based strain energy with analytical kinematics, stress push-forward, and tangent computation
+- **Energy-stress loss** -- Joint energy + stress gradient loss for thermodynamic consistency via autograd
+- **ICNN convexity** -- Input-Convex Neural Networks guarantee convexity of the predicted strain energy
 - **Fortran export** -- Transpile trained models to standalone Fortran 90 subroutines with baked-in weights
-- **Analytical UMAT** -- Generate optimized Fortran UMAT subroutines from symbolic expressions
+- **Analytical UMAT** -- Generate optimized Fortran UMAT subroutines from symbolic expressions via CSE
 
-## Quick start
+## Quick Start
+
+### MLP surrogate (stress-based)
 
 ```python
 import hyper_surrogate as hs
@@ -37,7 +76,29 @@ exported = hs.extract_weights(result.model, in_norm, out_norm)
 hs.FortranEmitter(exported).write("nn_surrogate.f90")
 ```
 
-See the [examples](https://jpsferreira.github.io/hyper-surrogate/examples/) for more usage patterns.
+### ICNN surrogate (energy-based)
+
+```python
+import hyper_surrogate as hs
+
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material, n_samples=5000, input_type="invariants", target_type="energy",
+)
+
+# ICNN guarantees convexity of the predicted strain energy
+model = hs.ICNN(input_dim=3, hidden_dims=[32, 32])
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=500,
+).fit()
+
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+exported.save("icnn_surrogate.npz")
+```
+
+See the [examples](https://jpsferreira.github.io/hyper-surrogate/examples/) for more usage patterns, including hybrid UMAT export and analytical Fortran generation.
 
 ## Installation
 
@@ -53,3 +114,25 @@ git clone https://github.com/jpsferreira/hyper-surrogate.git
 cd hyper-surrogate
 uv sync --all-groups --extra ml
 ```
+
+## Examples
+
+Runnable scripts are in the [`examples/`](examples/) directory:
+
+| Script                     | Description                                     |
+| -------------------------- | ----------------------------------------------- |
+| `train_neohooke_sef.py`    | Train MLP on NeoHooke SEF with hybrid inference |
+| `train_neohooke_stress.py` | Train MLP on PK2 stress with `StressLoss`       |
+| `train_icnn_energy.py`     | Train ICNN with `EnergyStressLoss`              |
+| `export_hybrid_umat.py`    | End-to-end train + `HybridUMATEmitter` export   |
+| `analytical_umat.py`       | Symbolic material to Fortran via `UMATHandler`  |
+
+Run any example with:
+
+```bash
+uv run python examples/<script>.py
+```
+
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and guidelines.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -64,7 +64,8 @@ result = hs.Trainer(
     lr=1e-3,
 ).fit()
 
-print(f"Best validation loss: {result.best_val_loss:.6f} (epoch {result.best_epoch})")
+best_val = result.history["val_loss"][result.best_epoch]
+print(f"Best validation loss: {best_val:.6f} (epoch {result.best_epoch})")
 
 # 3. Export weights and generate Fortran
 exported = hs.extract_weights(result.model, in_norm, out_norm)
@@ -105,6 +106,63 @@ result = hs.Trainer(
 exported = hs.extract_weights(result.model, in_norm, out_norm)
 exported.save("icnn_surrogate.npz")
 ```
+
+## Export a hybrid UMAT (NN energy + analytical mechanics)
+
+The `HybridUMATEmitter` generates a complete Abaqus UMAT subroutine where the neural network provides the strain energy function `W(I1_bar, I2_bar, J)` and everything else — kinematics, PK2 stress, Cauchy push-forward, and spatial tangent with Jaumann correction — is computed analytically in Fortran.
+
+```python
+import numpy as np
+import hyper_surrogate as hs
+from hyper_surrogate.data.dataset import MaterialDataset, Normalizer
+from hyper_surrogate.data.deformation import DeformationGenerator
+from hyper_surrogate.mechanics.kinematics import Kinematics
+
+# Generate training data with volumetric perturbation
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+gen = DeformationGenerator(seed=42)
+F = gen.combined(10000, stretch_range=(0.8, 1.3), shear_range=(-0.2, 0.2))
+rng = np.random.default_rng(99)
+J_target = rng.uniform(0.95, 1.05, size=10000)
+F = F * (J_target / np.linalg.det(F))[:, None, None] ** (1.0 / 3.0)
+C = Kinematics.right_cauchy_green(F)
+
+# Prepare invariant inputs and energy targets
+i1 = Kinematics.isochoric_invariant1(C)
+i2 = Kinematics.isochoric_invariant2(C)
+j = np.sqrt(Kinematics.det_invariant(C))
+inputs = np.column_stack([i1, i2, j])
+energy = material.evaluate_energy(C)
+dW_dI = material.evaluate_energy_grad_invariants(C)
+
+in_norm = Normalizer().fit(inputs)
+X = in_norm.transform(inputs).astype(np.float32)
+W = energy.reshape(-1, 1).astype(np.float32)
+S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+n_val = int(10000 * 0.15)
+idx = np.random.default_rng(42).permutation(10000)
+train_ds = MaterialDataset(X[idx[n_val:]], (W[idx[n_val:]], S[idx[n_val:]]))
+val_ds = MaterialDataset(X[idx[:n_val]], (W[idx[:n_val]], S[idx[:n_val]]))
+
+# Train energy MLP
+model = hs.MLP(input_dim=3, output_dim=1, hidden_dims=[64, 64, 64], activation="softplus")
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=2000, lr=1e-3, patience=200, batch_size=512,
+).fit()
+
+# Export hybrid UMAT
+energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+exported = hs.extract_weights(result.model, in_norm, energy_norm)
+emitter = hs.HybridUMATEmitter(exported)
+emitter.write("hybrid_umat.f90")
+```
+
+The generated `hybrid_umat.f90` contains a complete Fortran module with the NN forward/backward pass and a standard UMAT subroutine ready for Abaqus.
+
+See also the runnable scripts in the [`examples/`](https://github.com/jpsferreira/hyper-surrogate/tree/main/examples) directory.
 
 ## Kinematics utilities
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Examples
+
+Runnable scripts demonstrating the hyper-surrogate pipeline.
+
+| Script                     | Description                                                        | Run command                                       |
+| -------------------------- | ------------------------------------------------------------------ | ------------------------------------------------- |
+| `train_neohooke_sef.py`    | Train MLP on NeoHooke strain energy function with hybrid inference | `uv run python examples/train_neohooke_sef.py`    |
+| `train_neohooke_stress.py` | Train MLP on PK2 stress with `StressLoss`                          | `uv run python examples/train_neohooke_stress.py` |
+| `train_icnn_energy.py`     | Train ICNN with `EnergyStressLoss` for convex energy               | `uv run python examples/train_icnn_energy.py`     |
+| `export_hybrid_umat.py`    | End-to-end train + `HybridUMATEmitter` export                      | `uv run python examples/export_hybrid_umat.py`    |
+| `analytical_umat.py`       | Symbolic material to Fortran UMAT via `UMATHandler`                | `uv run python examples/analytical_umat.py`       |
+
+All examples follow the same structure: docstring, numbered sections, print statements for progress.

--- a/examples/analytical_umat.py
+++ b/examples/analytical_umat.py
@@ -1,0 +1,30 @@
+"""Generate an analytical Fortran UMAT from a symbolic material model.
+
+Uses SymPy common subexpression elimination (CSE) to produce an optimized
+Fortran 90 subroutine with Cauchy stress and spatial tangent stiffness.
+
+No neural network involved -- this is a purely symbolic approach.
+
+Usage:
+    uv run python examples/analytical_umat.py
+"""
+
+from hyper_surrogate.export.fortran.analytical import UMATHandler
+from hyper_surrogate.mechanics.materials import NeoHooke
+
+# ── 1. Define material ────────────────────────────────────────────
+print("── 1. Defining NeoHooke material ──")
+material = NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+print(f"  Parameters: {material._params}")
+
+# ── 2. Generate UMAT ─────────────────────────────────────────────
+print("\n── 2. Generating analytical UMAT ──")
+handler = UMATHandler(material)
+handler.generate("neohooke_analytical_umat.f")
+
+print("  Output: neohooke_analytical_umat.f")
+print("\nThe generated UMAT contains:")
+print("  - Cauchy stress (Voigt notation) from symbolic PK2")
+print("  - Spatial tangent stiffness with Jaumann rate correction")
+print("  - Common subexpression elimination for performance")
+print("  - Ready for Abaqus or LS-DYNA")

--- a/examples/export_hybrid_umat.py
+++ b/examples/export_hybrid_umat.py
@@ -1,0 +1,93 @@
+"""End-to-end: train an MLP on strain energy and export a hybrid UMAT.
+
+The hybrid UMAT combines:
+- NN-based strain energy function W(I1_bar, I2_bar, J)
+- Analytical kinematics: F -> C -> invariants
+- Analytical stress: PK2 = 2 * sum(dW/dIk * dIk/dC), Cauchy = (1/J) F S F^T
+- Analytical tangent: material tangent + push-forward + Jaumann correction
+
+Usage:
+    uv run python examples/export_hybrid_umat.py
+"""
+
+import numpy as np
+
+import hyper_surrogate as hs
+from hyper_surrogate.data.dataset import MaterialDataset, Normalizer
+from hyper_surrogate.data.deformation import DeformationGenerator
+from hyper_surrogate.mechanics.kinematics import Kinematics
+
+# ── 1. Material and deformation data ──────────────────────────────
+print("── 1. Generating training data ──")
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+n = 10000
+
+gen = DeformationGenerator(seed=42)
+F_base = gen.combined(n, stretch_range=(0.8, 1.3), shear_range=(-0.2, 0.2))
+
+# Add volumetric perturbation
+rng = np.random.default_rng(99)
+J_target = rng.uniform(0.95, 1.05, size=n)
+J_current = np.linalg.det(F_base)
+F = F_base * (J_target / J_current)[:, None, None] ** (1.0 / 3.0)
+C = Kinematics.right_cauchy_green(F)
+
+# ── 2. Inputs and targets ─────────────────────────────────────────
+i1 = Kinematics.isochoric_invariant1(C)
+i2 = Kinematics.isochoric_invariant2(C)
+j = np.sqrt(Kinematics.det_invariant(C))
+inputs = np.column_stack([i1, i2, j])
+
+energy = material.evaluate_energy(C)
+dW_dI = material.evaluate_energy_grad_invariants(C)
+
+print(f"  Samples: {n}")
+print(f"  I1=[{i1.min():.3f}, {i1.max():.3f}]")
+print(f"  J =[{j.min():.4f}, {j.max():.4f}]")
+
+# ── 3. Normalize and build datasets ───────────────────────────────
+in_norm = Normalizer().fit(inputs)
+X = in_norm.transform(inputs).astype(np.float32)
+W = energy.reshape(-1, 1).astype(np.float32)
+S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+n_val = int(n * 0.15)
+idx = np.random.default_rng(42).permutation(n)
+ti, vi = idx[n_val:], idx[:n_val]
+
+train_ds = MaterialDataset(X[ti], (W[ti], S[ti]))
+val_ds = MaterialDataset(X[vi], (W[vi], S[vi]))
+
+# ── 4. Train ──────────────────────────────────────────────────────
+print("\n── 2. Training MLP ──")
+model = hs.MLP(input_dim=3, output_dim=1, hidden_dims=[64, 64, 64], activation="softplus")
+result = hs.Trainer(
+    model,
+    train_ds,
+    val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=2000,
+    lr=1e-3,
+    patience=200,
+    batch_size=512,
+).fit()
+
+best_val = result.history["val_loss"][result.best_epoch]
+print(f"  Best val loss: {best_val:.6f} (epoch {result.best_epoch})")
+
+# ── 5. Export hybrid UMAT ─────────────────────────────────────────
+print("\n── 3. Exporting hybrid UMAT ──")
+energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+exported = hs.extract_weights(result.model, in_norm, energy_norm)
+exported.save("mlp_hybrid_sef.npz")
+
+emitter = hs.HybridUMATEmitter(exported)
+emitter.write("hybrid_umat.f90")
+
+print("  Weights:  mlp_hybrid_sef.npz")
+print("  UMAT:     hybrid_umat.f90")
+print("\nThe generated UMAT contains:")
+print("  - NN forward + backward pass (dW/dI via backprop)")
+print("  - Analytical kinematics (F -> C -> invariants)")
+print("  - Analytical PK2 stress and Cauchy push-forward")
+print("  - Material tangent with Jaumann correction")

--- a/examples/train_icnn_energy.py
+++ b/examples/train_icnn_energy.py
@@ -1,0 +1,52 @@
+"""Train an ICNN to learn a convex strain energy function.
+
+Energy-based approach with convexity guarantee:
+1. Generate invariant inputs and energy + stress gradient targets
+2. Train ICNN (Input-Convex Neural Network) with EnergyStressLoss
+3. ICNN guarantees convexity of W(I) -> thermodynamic consistency
+4. Export weights for downstream use
+
+Usage:
+    uv run python examples/train_icnn_energy.py
+"""
+
+import hyper_surrogate as hs
+
+# ── 1. Material and training data ─────────────────────────────────
+print("── 1. Generating training data ──")
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+
+# Energy target: dataset stores (energy, dW/d_invariants) as a tuple
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material,
+    n_samples=5000,
+    input_type="invariants",
+    target_type="energy",
+)
+
+print(f"  Train samples: {len(train_ds)}")
+print(f"  Val samples:   {len(val_ds)}")
+
+# ── 2. Build and train the ICNN ───────────────────────────────────
+print("\n── 2. Training ICNN ──")
+# ICNN outputs a scalar (energy); stress is enforced via autograd in the loss
+model = hs.ICNN(input_dim=3, hidden_dims=[32, 32])
+result = hs.Trainer(
+    model,
+    train_ds,
+    val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=500,
+    lr=1e-3,
+).fit()
+
+best_val = result.history["val_loss"][result.best_epoch]
+print(f"  Best val loss: {best_val:.6f} (epoch {result.best_epoch})")
+print(f"  Total epochs:  {len(result.history["train_loss"])}")
+
+# ── 3. Export weights ─────────────────────────────────────────────
+print("\n── 3. Exporting ──")
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+exported.save("icnn_neohooke_energy.npz")
+
+print("  Weights: icnn_neohooke_energy.npz")

--- a/examples/train_neohooke_stress.py
+++ b/examples/train_neohooke_stress.py
@@ -1,0 +1,53 @@
+"""Train an MLP to predict PK2 stress directly using StressLoss.
+
+Supervised approach:
+1. Generate deformation data and compute PK2 stress in Voigt notation
+2. Train MLP mapping invariants -> PK2 stress (6 components)
+3. Export to standalone Fortran 90 module
+
+Usage:
+    uv run python examples/train_neohooke_stress.py
+"""
+
+import hyper_surrogate as hs
+
+# ── 1. Material and training data ─────────────────────────────────
+print("── 1. Generating training data ──")
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material,
+    n_samples=5000,
+    input_type="invariants",  # 3 inputs: I1_bar, I2_bar, J
+    target_type="pk2_voigt",  # 6 outputs: PK2 stress in Voigt notation
+)
+
+print(f"  Train samples: {len(train_ds)}")
+print(f"  Val samples:   {len(val_ds)}")
+
+# ── 2. Build and train the model ──────────────────────────────────
+print("\n── 2. Training MLP ──")
+model = hs.MLP(input_dim=3, output_dim=6, hidden_dims=[32, 32], activation="tanh")
+result = hs.Trainer(
+    model,
+    train_ds,
+    val_ds,
+    loss_fn=hs.StressLoss(),
+    max_epochs=500,
+    lr=1e-3,
+).fit()
+
+best_val = result.history["val_loss"][result.best_epoch]
+print(f"  Best val loss: {best_val:.6f} (epoch {result.best_epoch})")
+print(f"  Total epochs:  {len(result.history["train_loss"])}")
+
+# ── 3. Export to Fortran ──────────────────────────────────────────
+print("\n── 3. Exporting ──")
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+exported.save("mlp_neohooke_stress.npz")
+
+emitter = hs.FortranEmitter(exported)
+emitter.write("nn_neohooke_stress.f90")
+
+print("  Weights:  mlp_neohooke_stress.npz")
+print("  Fortran:  nn_neohooke_stress.f90")


### PR DESCRIPTION
## Summary
- Rewrite CONTRIBUTING.md: replace poetry with uv, remove tox/Cookiecutter boilerplate, add code style and slow test docs
- Enhance README.md: add motivation section, architecture diagram, ICNN quickstart, examples table, contributing link
- Create CLAUDE.md with project conventions and key commands
- Add 4 example scripts: stress MLP, ICNN energy, hybrid UMAT export, analytical UMAT
- Fix docs/examples.md: correct `best_val_loss` reference, add hybrid UMAT example section

## Test plan
- [x] `make check` passes (ruff, mypy, deptry)
- [x] `make test` passes (112 tests)
- [x] `make docs-test` passes (mkdocs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)