### PR TITLE
Replace FD Hessian with exact analytical d²W/dI²

### DIFF
--- a/hyper_surrogate/export/fortran/hybrid.py
+++ b/hyper_surrogate/export/fortran/hybrid.py
@@ -86,24 +86,23 @@ class HybridUMATEmitter:
         for i in range(n_layers):
             lines.append(f"DOUBLE PRECISION :: z{i}({hidden_dims[i]})")
             lines.append(f"DOUBLE PRECISION :: a{i}({hidden_dims[i]})")  # pre-activation
+            lines.append(f"DOUBLE PRECISION :: dact{i}({hidden_dims[i]})")  # activation derivative
+            lines.append(f"DOUBLE PRECISION :: d2act{i}({hidden_dims[i]})")  # second derivative
         lines.append(f"DOUBLE PRECISION :: x_norm({in_dim})")
         lines.append("")
 
         # Local variables for backward pass
-        for i in range(n_layers):
-            lines.append(f"DOUBLE PRECISION :: dact{i}({hidden_dims[i]})")  # activation derivative
-        # delta vectors for backprop
         for i in range(n_layers - 1, -1, -1):
             lines.append(f"DOUBLE PRECISION :: delta{i}({hidden_dims[i]})")
         lines.append(f"DOUBLE PRECISION :: grad_x({in_dim})")
         lines.append("")
 
-        # For second derivatives (Gauss-Newton approximation: J^T J through layers)
-        # We propagate a (hidden_dim x in_dim) Jacobian through the network
+        # For Jacobian propagation and Hessian
         for i in range(n_layers):
+            lines.append(f"DOUBLE PRECISION :: P{i}({hidden_dims[i]},{in_dim})")
             lines.append(f"DOUBLE PRECISION :: J{i}({hidden_dims[i]},{in_dim})")
-        lines.append(f"DOUBLE PRECISION :: dW_dx({in_dim})")
         lines.append(f"DOUBLE PRECISION :: d2W_dx2({in_dim},{in_dim})")
+        lines.append("DOUBLE PRECISION :: coeff")
         lines.append("")
 
         # --- Normalize input ---
@@ -111,7 +110,7 @@ class HybridUMATEmitter:
         lines.append("x_norm = (nn_input - in_mean) / in_std")
         lines.append("")
 
-        # --- Forward pass ---
+        # --- Forward pass with d2act ---
         lines.append("! Forward pass")
         for i, layer in enumerate(layers):
             input_var = "x_norm" if i == 0 else f"z{i - 1}"
@@ -120,12 +119,15 @@ class HybridUMATEmitter:
             if act == "identity":
                 lines.append(f"z{i} = a{i}")
                 lines.append(f"dact{i} = 1.0d0")
+                lines.append(f"d2act{i} = 0.0d0")
             elif act == "tanh":
                 lines.append(f"z{i} = tanh(a{i})")
                 lines.append(f"dact{i} = 1.0d0 - z{i}**2")
+                lines.append(f"d2act{i} = -2.0d0 * z{i} * dact{i}")
             elif act == "softplus":
                 lines.append(f"z{i} = log(1.0d0 + exp(a{i}))")
                 lines.append(f"dact{i} = 1.0d0 / (1.0d0 + exp(-a{i}))")
+                lines.append(f"d2act{i} = dact{i} * (1.0d0 - dact{i})")
             elif act == "relu":
                 lines.append(f"DO ii = 1, {hidden_dims[i]}")
                 lines.append(f"  z{i}(ii) = max(0.0d0, a{i}(ii))")
@@ -134,10 +136,12 @@ class HybridUMATEmitter:
                 lines.append("  ELSE")
                 lines.append(f"    dact{i}(ii) = 0.0d0")
                 lines.append("  END IF")
+                lines.append(f"  d2act{i}(ii) = 0.0d0")
                 lines.append("END DO")
             elif act == "sigmoid":
                 lines.append(f"z{i} = 1.0d0 / (1.0d0 + exp(-a{i}))")
                 lines.append(f"dact{i} = z{i} * (1.0d0 - z{i})")
+                lines.append(f"d2act{i} = dact{i} * (1.0d0 - 2.0d0 * z{i})")
             lines.append("")
 
         # W = z_{last}(1) (scalar output)
@@ -169,49 +173,64 @@ class HybridUMATEmitter:
         lines.append("")
 
         # dW/dI = dW/dx_norm / std (chain rule for normalization)
-        lines.append("! Convert to raw invariant space: dW/dI = dW/dx_norm / std")
-        lines.append("dW_dI(1) = grad_x(1) / in_std(1)")
-        lines.append("dW_dI(2) = grad_x(2) / in_std(2)")
-        lines.append("dW_dI(3) = grad_x(3) / in_std(3)")
+        lines.append("! Convert gradient to raw invariant space: dW/dI = dW/dx_norm / std")
+        for k in range(in_dim):
+            lines.append(f"dW_dI({k + 1}) = grad_x({k + 1}) / in_std({k + 1})")
         lines.append("")
 
-        # --- Second derivatives: d²W/dI² via Jacobian propagation ---
-        lines.append("! Second derivatives: d²W/dI² via Jacobian forward mode")
-        # J0 = diag(dact0) * W0  (hidden0 x in_dim)
+        # --- Jacobian propagation: P_i = W_i * J_{i-1}, J_i = diag(dact_i) * P_i ---
+        lines.append("! Jacobian propagation (forward mode)")
+        # P0 = W0, J0 = diag(dact0) * W0
         lines.append(f"DO ii = 1, {hidden_dims[0]}")
         lines.append(f"  DO jj = 1, {in_dim}")
+        lines.append("    P0(ii, jj) = w0(ii, jj)")
         lines.append("    J0(ii, jj) = dact0(ii) * w0(ii, jj)")
         lines.append("  END DO")
         lines.append("END DO")
 
         for i in range(1, n_layers):
-            # J_i = diag(dact_i) * W_i * J_{i-1}
+            # P_i = W_i * J_{i-1}  (pre-activation Jacobian)
+            # J_i = diag(dact_i) * P_i
             lines.append(f"DO ii = 1, {hidden_dims[i]}")
             lines.append(f"  DO jj = 1, {in_dim}")
-            lines.append(f"    J{i}(ii, jj) = 0.0d0")
+            lines.append(f"    P{i}(ii, jj) = 0.0d0")
             lines.append(f"    DO kk = 1, {hidden_dims[i - 1]}")
-            lines.append(f"      J{i}(ii, jj) = J{i}(ii, jj) + w{i}(ii, kk) * J{i - 1}(kk, jj)")
+            lines.append(f"      P{i}(ii, jj) = P{i}(ii, jj) + w{i}(ii, kk) * J{i - 1}(kk, jj)")
             lines.append("    END DO")
-            lines.append(f"    J{i}(ii, jj) = dact{i}(ii) * J{i}(ii, jj)")
+            lines.append(f"    J{i}(ii, jj) = dact{i}(ii) * P{i}(ii, jj)")
             lines.append("  END DO")
             lines.append("END DO")
-
-        # d²W/dx_norm² ≈ J_last^T * J_last  (Gauss-Newton approx for scalar output)
-        # But for scalar output with identity last activation, J_last IS the exact Hessian row
-        # Actually for scalar output: dW/dx = J_last(1,:), and we need the full Hessian.
-        # The exact Hessian requires second-order activation terms. For softplus/tanh
-        # the GN approximation J^T J is NOT the Hessian. We need the exact Hessian.
-        #
-        # Exact approach: propagate Hessian through each layer.
-        # For layer i: H_i = diag(dact_i) * W_i * H_{i-1} * W_i^T * diag(dact_i)
-        #            + diag(d2act_i * (W_i * J_{i-1})^2)  [element-wise]
-        # This is complex. For now, use numerical perturbation for d²W/dI².
-
         lines.append("")
-        lines.append("! d²W/dI² via finite differences on dW/dI")
-        lines.append("! (exact analytical Hessian through NN layers is also possible)")
-        lines.append("! We perturb each invariant and recompute dW/dI")
-        lines.append("! This is done in the main UMAT body below")
+
+        # --- Exact analytical Hessian: d²W/dx² = Σ_i P_i^T diag(beta_i * d2act_i) P_i ---
+        # beta_i = delta_i / dact_i = dW/dz_i (sensitivity to post-activation)
+        lines.append("! Exact analytical Hessian: d²W/dx_norm²")
+        lines.append("d2W_dx2 = 0.0d0")
+        for i in range(n_layers):
+            act = layers[i].activation
+            # Skip layers with zero d2act (relu, identity) — they contribute nothing
+            if act in ("relu", "identity"):
+                lines.append(f"! Layer {i} ({act}): d2act=0, no Hessian contribution")
+                continue
+            lines.append(f"! Layer {i} ({act})")
+            lines.append(f"DO ii = 1, {hidden_dims[i]}")
+            # coeff = beta_i(ii) * d2act_i(ii) = (delta_i(ii) / dact_i(ii)) * d2act_i(ii)
+            lines.append(f"  coeff = delta{i}(ii) / dact{i}(ii) * d2act{i}(ii)")
+            lines.append(f"  DO jj = 1, {in_dim}")
+            lines.append(f"    DO kk = 1, {in_dim}")
+            lines.append(f"      d2W_dx2(jj, kk) = d2W_dx2(jj, kk) + coeff * P{i}(ii, jj) * P{i}(ii, kk)")
+            lines.append("    END DO")
+            lines.append("  END DO")
+            lines.append("END DO")
+        lines.append("")
+
+        # Convert to raw invariant space: d2W/dI2(k,l) = d2W/dx2(k,l) / (std(k) * std(l))
+        lines.append("! Convert Hessian to raw invariant space: d2W/dI2(k,l) = d2W/dx2(k,l) / (std(k)*std(l))")
+        lines.append(f"DO ii = 1, {in_dim}")
+        lines.append(f"  DO jj = 1, {in_dim}")
+        lines.append("    d2W_dI2(ii, jj) = d2W_dx2(ii, jj) / (in_std(ii) * in_std(jj))")
+        lines.append("  END DO")
+        lines.append("END DO")
 
         return "\n".join(lines)
 
@@ -222,33 +241,6 @@ class HybridUMATEmitter:
         layers = self.exported.layers
         weights = self.exported.weights
         hidden_dims = [weights[layer.weights].shape[0] for layer in layers]
-
-        # Build the activation code snippets for the perturbation loop
-        def activation_block(layer_idx: int, prefix: str = "") -> str:
-            act = layers[layer_idx].activation
-            var_z = f"{prefix}z{layer_idx}"
-            var_a = f"{prefix}a{layer_idx}"
-            var_dact = f"{prefix}dact{layer_idx}"
-            if act == "identity":
-                return f"{var_z} = {var_a}\n{var_dact} = 1.0d0"
-            elif act == "tanh":
-                return f"{var_z} = tanh({var_a})\n{var_dact} = 1.0d0 - {var_z}**2"
-            elif act == "softplus":
-                return f"{var_z} = log(1.0d0 + exp({var_a}))\n{var_dact} = 1.0d0 / (1.0d0 + exp(-{var_a}))"
-            elif act == "sigmoid":
-                return f"{var_z} = 1.0d0 / (1.0d0 + exp(-{var_a}))\n{var_dact} = {var_z} * (1.0d0 - {var_z})"
-            elif act == "relu":
-                return (
-                    f"DO ii = 1, {hidden_dims[layer_idx]}\n"
-                    f"  {var_z}(ii) = max(0.0d0, {var_a}(ii))\n"
-                    f"  IF ({var_a}(ii) > 0.0d0) THEN\n"
-                    f"    {var_dact}(ii) = 1.0d0\n"
-                    f"  ELSE\n"
-                    f"    {var_dact}(ii) = 0.0d0\n"
-                    f"  END IF\n"
-                    f"END DO"
-                )
-            return ""
 
         code = f"""\
 !>********************************************************************
@@ -273,14 +265,15 @@ MODULE nn_sef
 
 CONTAINS
 
-  SUBROUTINE nn_eval(nn_input, W_nn, dW_dI)
-    !> Evaluate NN: W(I1_bar, I2_bar, J) and dW/dI via backprop
+  SUBROUTINE nn_eval(nn_input, W_nn, dW_dI, d2W_dI2)
+    !> Evaluate NN: W(I1_bar, I2_bar, J), dW/dI, and d²W/dI² via backprop
     DOUBLE PRECISION, INTENT(IN)  :: nn_input(3)
     DOUBLE PRECISION, INTENT(OUT) :: W_nn
     DOUBLE PRECISION, INTENT(OUT) :: dW_dI(3)
+    DOUBLE PRECISION, INTENT(OUT) :: d2W_dI2(3,3)
 
     ! Local variables
-    INTEGER :: ii, jj
+    INTEGER :: ii, jj, kk
     {self._emit_nn_forward_and_backward()}
 
   END SUBROUTINE nn_eval
@@ -323,9 +316,7 @@ SUBROUTINE umat(stress, statev, ddsdde, sse, spd, scd, rpl, &
   DOUBLE PRECISION :: Jm23, Jm43
   INTEGER :: ii, jj, kk, ll
 
-  ! For tangent via numerical differentiation of dW/dI
-  DOUBLE PRECISION :: eps_fd
-  DOUBLE PRECISION :: nn_input_p(3), dW_dI_p(3), W_p
+  ! d²W/dI² from analytical NN Hessian
   DOUBLE PRECISION :: d2W_dI2(3,3)
 
   ! For tangent: material tangent in reference config
@@ -385,7 +376,7 @@ SUBROUTINE umat(stress, statev, ddsdde, sse, spd, scd, rpl, &
   nn_input(1) = I1_bar
   nn_input(2) = I2_bar
   nn_input(3) = Jac
-  CALL nn_eval(nn_input, W_nn, dW_dI)
+  CALL nn_eval(nn_input, W_nn, dW_dI, d2W_dI2)
 
   ! Store strain energy
   sse = W_nn
@@ -460,27 +451,7 @@ SUBROUTINE umat(stress, statev, ddsdde, sse, spd, scd, rpl, &
   END DO
 
   ! ================================================================
-  ! 6. Tangent: d²W/dI² via finite differences on NN
-  ! ================================================================
-  eps_fd = 1.0d-6
-  DO ii = 1, 3
-    nn_input_p = nn_input
-    nn_input_p(ii) = nn_input_p(ii) + eps_fd
-    CALL nn_eval(nn_input_p, W_p, dW_dI_p)
-    DO jj = 1, 3
-      d2W_dI2(jj, ii) = (dW_dI_p(jj) - dW_dI(jj)) / eps_fd
-    END DO
-  END DO
-  ! Symmetrize
-  DO ii = 1, 3
-    DO jj = ii+1, 3
-      d2W_dI2(ii,jj) = 0.5d0 * (d2W_dI2(ii,jj) + d2W_dI2(jj,ii))
-      d2W_dI2(jj,ii) = d2W_dI2(ii,jj)
-    END DO
-  END DO
-
-  ! ================================================================
-  ! 7. Material tangent: C_ABCD = 4 * d²W/dC²
+  ! 6. Material tangent: C_ABCD = 4 * d²W/dC²
   !    d²W/dCdC = sum_k sum_l (d²W/dIk*dIl) * (dIk/dC) x (dIl/dC)
   !             + sum_k (dW/dIk) * (d²Ik/dCdC)
   !
@@ -588,7 +559,7 @@ SUBROUTINE umat(stress, statev, ddsdde, sse, spd, scd, rpl, &
   END BLOCK
 
   ! ================================================================
-  ! 8. Push forward to spatial tangent: c_ijkl = (1/J) F_iA F_jB F_kC F_lD C_ABCD
+  ! 7. Push forward to spatial tangent: c_ijkl = (1/J) F_iA F_jB F_kC F_lD C_ABCD
   ! ================================================================
   cmat_spatial = 0.0d0
   DO ii = 1, 3

--- a/tests/test_hybrid_emitter.py
+++ b/tests/test_hybrid_emitter.py
@@ -68,12 +68,14 @@ def test_emit_activations():
         assert "SUBROUTINE nn_eval" in code
 
 
-def test_emit_finite_differences():
+def test_emit_analytical_hessian():
     exported = _make_scalar_model()
     code = HybridUMATEmitter(exported).emit()
-    # Check for d²W/dI² via FD
-    assert "eps_fd" in code
+    # Check for analytical Hessian (no FD)
+    assert "eps_fd" not in code
     assert "d2W_dI2" in code
+    assert "d2act" in code
+    assert "d2W_dx2" in code
 
 
 def test_write_to_file(tmp_path):

--- a/tests/test_hybrid_hessian.py
+++ b/tests/test_hybrid_hessian.py
@@ -1,0 +1,222 @@
+"""Tests for analytical Hessian in HybridUMATEmitter.
+
+Validates the exact d²W/dI² computation against PyTorch autograd
+for various activations and architectures.
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch.autograd.functional import hessian  # noqa: E402
+
+from hyper_surrogate.data.dataset import Normalizer  # noqa: E402
+from hyper_surrogate.export.fortran.hybrid import HybridUMATEmitter  # noqa: E402
+from hyper_surrogate.export.weights import extract_weights  # noqa: E402
+from hyper_surrogate.models.mlp import MLP  # noqa: E402
+
+
+def _make_model(activation="softplus", hidden_dims=None):
+    if hidden_dims is None:
+        hidden_dims = [8, 8]
+    model = MLP(input_dim=3, output_dim=1, hidden_dims=hidden_dims, activation=activation)
+    in_norm = Normalizer().fit(np.random.default_rng(42).standard_normal((50, 3)))
+    energy_norm = Normalizer().fit(np.random.default_rng(42).standard_normal((50, 1)))
+    return model, in_norm, energy_norm
+
+
+def _pytorch_hessian(model, in_norm, x_raw):
+    """Compute d²W/dI² using PyTorch autograd on raw (un-normalized) inputs."""
+    model.eval()
+    std = torch.tensor(in_norm.params["std"], dtype=torch.float32)
+    mean = torch.tensor(in_norm.params["mean"], dtype=torch.float32)
+
+    def f(x):
+        x_norm = (x - mean) / std
+        return model(x_norm.unsqueeze(0)).squeeze()
+
+    x_t = torch.tensor(x_raw, dtype=torch.float32)
+    H = hessian(f, x_t)
+    return H.detach().numpy()
+
+
+def _forward_pass(layers, weights, x_norm):
+    """Run forward pass, returning activations and derivatives per layer."""
+    dacts = []
+    d2acts = []
+    h = x_norm.copy()
+    for layer in layers:
+        w = weights[layer.weights]
+        b = weights[layer.bias]
+        a = w @ h + b
+
+        act = layer.activation
+        if act == "softplus":
+            z = np.log(1.0 + np.exp(a))
+            da = 1.0 / (1.0 + np.exp(-a))
+            d2a = da * (1.0 - da)
+        elif act == "tanh":
+            z = np.tanh(a)
+            da = 1.0 - z**2
+            d2a = -2.0 * z * da
+        elif act == "sigmoid":
+            z = 1.0 / (1.0 + np.exp(-a))
+            da = z * (1.0 - z)
+            d2a = da * (1.0 - 2.0 * z)
+        elif act == "relu":
+            z = np.maximum(0.0, a)
+            da = (a > 0).astype(float)
+            d2a = np.zeros_like(a)
+        else:  # identity
+            z = a.copy()
+            da = np.ones_like(a)
+            d2a = np.zeros_like(a)
+
+        dacts.append(da)
+        d2acts.append(d2a)
+        h = z
+    return dacts, d2acts
+
+
+def _emitter_hessian(model, in_norm, energy_norm, x_raw):
+    """Compute d²W/dI² by manually executing the emitter's analytical Hessian logic in Python."""
+    exported = extract_weights(model, in_norm, energy_norm)
+    layers = exported.layers
+    weights = exported.weights
+    in_std = exported.input_normalizer["std"]
+    in_mean = exported.input_normalizer["mean"]
+
+    # Normalize input and run forward pass
+    x_norm = (x_raw - in_mean) / in_std
+    dacts, d2acts = _forward_pass(layers, weights, x_norm)
+
+    n_layers = len(layers)
+    in_dim = len(x_norm)
+
+    # Backward pass (delta = dW/da)
+    deltas = [None] * n_layers
+    last = n_layers - 1
+    deltas[last] = np.zeros(len(dacts[last]))
+    deltas[last][0] = dacts[last][0]  # scalar output
+
+    for i in range(last - 1, -1, -1):
+        w_next = weights[layers[i + 1].weights]
+        deltas[i] = (w_next.T @ deltas[i + 1]) * dacts[i]
+
+    # Jacobian propagation: P_i (pre-activation), J_i (post-activation)
+    Ps = []
+    Js = []
+    w0 = weights[layers[0].weights]
+    P0 = w0.copy()
+    J0 = np.diag(dacts[0]) @ w0
+    Ps.append(P0)
+    Js.append(J0)
+
+    for i in range(1, n_layers):
+        wi = weights[layers[i].weights]
+        Pi = wi @ Js[i - 1]
+        Ji = np.diag(dacts[i]) @ Pi
+        Ps.append(Pi)
+        Js.append(Ji)
+
+    # Hessian accumulation
+    d2W_dx2 = np.zeros((in_dim, in_dim))
+    for i in range(n_layers):
+        act = layers[i].activation
+        if act in ("relu", "identity"):
+            continue
+        for j in range(len(dacts[i])):
+            coeff = deltas[i][j] / dacts[i][j] * d2acts[i][j]
+            d2W_dx2 += coeff * np.outer(Ps[i][j, :], Ps[i][j, :])
+
+    # Convert to raw invariant space
+    d2W_dI2 = d2W_dx2 / np.outer(in_std, in_std)
+    return d2W_dI2
+
+
+@pytest.mark.parametrize("activation", ["softplus", "tanh", "sigmoid"])
+def test_hessian_matches_pytorch(activation):
+    """Compare analytical Hessian against PyTorch autograd for smooth activations."""
+    model, in_norm, energy_norm = _make_model(activation=activation, hidden_dims=[8, 8])
+    rng = np.random.default_rng(123)
+    x_raw = rng.standard_normal(3).astype(np.float64)
+
+    H_torch = _pytorch_hessian(model, in_norm, x_raw)
+    H_analytical = _emitter_hessian(model, in_norm, energy_norm, x_raw)
+
+    np.testing.assert_allclose(H_analytical, H_torch, atol=1e-5, rtol=1e-4)
+
+
+def test_hessian_symmetry():
+    """Analytical Hessian should be symmetric."""
+    model, in_norm, energy_norm = _make_model(activation="softplus")
+    x_raw = np.array([3.1, 3.0, 1.0])
+    H = _emitter_hessian(model, in_norm, energy_norm, x_raw)
+    np.testing.assert_allclose(H, H.T, atol=1e-12)
+
+
+def test_hessian_relu_is_zero():
+    """ReLU has zero second derivative, so Hessian contribution should be zero."""
+    model, in_norm, energy_norm = _make_model(activation="relu")
+    x_raw = np.array([3.1, 3.0, 1.0])
+    H = _emitter_hessian(model, in_norm, energy_norm, x_raw)
+    np.testing.assert_allclose(H, 0.0, atol=1e-12)
+
+
+@pytest.mark.parametrize("hidden_dims", [[16], [8, 8, 8], [4, 8, 4]])
+def test_hessian_various_architectures(hidden_dims):
+    """Analytical Hessian matches PyTorch for different layer configurations."""
+    model, in_norm, energy_norm = _make_model(activation="softplus", hidden_dims=hidden_dims)
+    rng = np.random.default_rng(456)
+    x_raw = rng.standard_normal(3).astype(np.float64)
+
+    H_torch = _pytorch_hessian(model, in_norm, x_raw)
+    H_analytical = _emitter_hessian(model, in_norm, energy_norm, x_raw)
+
+    np.testing.assert_allclose(H_analytical, H_torch, atol=1e-5, rtol=1e-4)
+
+
+def test_d2act_softplus():
+    """Verify softplus second derivative formula: dact * (1 - dact)."""
+    a = np.linspace(-3, 3, 100)
+    dact = 1.0 / (1.0 + np.exp(-a))  # sigmoid
+    d2act = dact * (1.0 - dact)
+    # Compare with numerical second derivative of softplus
+    h = 1e-5
+    sp = lambda x: np.log(1.0 + np.exp(x))
+    d2_num = (sp(a + h) - 2 * sp(a) + sp(a - h)) / h**2
+    np.testing.assert_allclose(d2act, d2_num, atol=1e-4)
+
+
+def test_d2act_tanh():
+    """Verify tanh second derivative formula: -2 * z * dact."""
+    a = np.linspace(-3, 3, 100)
+    z = np.tanh(a)
+    dact = 1.0 - z**2
+    d2act = -2.0 * z * dact
+    h = 1e-5
+    d2_num = (np.tanh(a + h) - 2 * np.tanh(a) + np.tanh(a - h)) / h**2
+    np.testing.assert_allclose(d2act, d2_num, atol=1e-4)
+
+
+def test_d2act_sigmoid():
+    """Verify sigmoid second derivative formula: dact * (1 - 2*z)."""
+    a = np.linspace(-3, 3, 100)
+    z = 1.0 / (1.0 + np.exp(-a))
+    dact = z * (1.0 - z)
+    d2act = dact * (1.0 - 2.0 * z)
+    h = 1e-5
+    sig = lambda x: 1.0 / (1.0 + np.exp(-x))
+    d2_num = (sig(a + h) - 2 * sig(a) + sig(a - h)) / h**2
+    np.testing.assert_allclose(d2act, d2_num, atol=1e-4)
+
+
+def test_generated_fortran_has_d2act_no_eps_fd():
+    """Generated Fortran should contain d2act but not eps_fd."""
+    model, in_norm, energy_norm = _make_model(activation="softplus")
+    exported = extract_weights(model, in_norm, energy_norm)
+    code = HybridUMATEmitter(exported).emit()
+    assert "d2act" in code
+    assert "d2W_dI2" in code
+    assert "eps_fd" not in code
+    assert "nn_input_p" not in code


### PR DESCRIPTION
## Summary
- Replace finite-difference `d²W/dI²` in `HybridUMATEmitter` with exact analytical Hessian propagation through NN layers
- Eliminates 3 extra `nn_eval` calls per integration point and removes O(ε²) truncation error from the material tangent
- Formula: `d²W/dx² = Σ_i P_i^T diag(β_i · φ''(a_i)) P_i` where `P_i = W_i J_{i-1}` and `β_i = dW/dz_i`
- Add `d2act` computation for softplus, tanh, sigmoid, relu, identity
- Extend `nn_eval` signature with `d2W_dI2(3,3)` output parameter
- Add 12 new tests validating against `torch.autograd.functional.hessian`

## Test plan
- [x] `make check` passes (ruff, mypy, deptry)
- [x] `make test` passes (124 tests, 6 deselected slow)
- [x] Analytical Hessian matches PyTorch autograd for softplus, tanh, sigmoid
- [x] ReLU Hessian correctly returns zero
- [x] Hessian is symmetric
- [x] Works across architectures: [16], [8,8], [8,8,8], [4,8,4]
- [x] Generated Fortran contains `d2act`, no `eps_fd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)