### PR TITLE
Add PolyconvexICNN: multi-branch ICNN with polyconvex energy

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -162,8 +162,6 @@ emitter.write("hybrid_umat.f90")
 
 The generated `hybrid_umat.f90` contains a complete Fortran module with the NN forward/backward pass and a standard UMAT subroutine ready for Abaqus.
 
-The generated `hybrid_umat.f90` contains a complete Fortran module with the NN forward/backward pass and a standard UMAT subroutine ready for Abaqus.
-
 ## Anisotropic model: Holzapfel-Ogden with fiber invariants
 
 For transversely isotropic materials, the NN takes 5 invariants: `W(I1_bar, I2_bar, J, I4, I5)` where I4 and I5 are fiber invariants.
@@ -198,6 +196,39 @@ dW_dI = material.evaluate_energy_grad_invariants(C)
 ```
 
 See `examples/train_holzapfel_ogden.py` for the complete runnable script.
+
+## Polyconvex energy with PolyconvexICNN
+
+`PolyconvexICNN` guarantees convexity per invariant group by using independent ICNN branches. The total energy is the sum of branch outputs — convex superposition preserves convexity.
+
+```python
+import hyper_surrogate as hs
+
+# Each invariant gets its own convex branch
+model = hs.PolyconvexICNN(
+    groups=[[0], [1], [2]],      # W = W1(I1) + W2(I2) + W3(J)
+    hidden_dims=[32, 32],
+    activation="softplus",
+)
+
+# For anisotropic materials, group fiber invariants:
+# groups=[[0], [1], [2], [3, 4]]  ->  W = W1(I1) + W2(I2) + W3(J) + W4(I4, I5)
+
+# Train with EnergyStressLoss (same as MLP/ICNN)
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=2000, lr=1e-3,
+).fit()
+
+# Export: both FortranEmitter and HybridUMATEmitter support polyconvex
+exported = hs.extract_weights(result.model, in_norm, energy_norm)
+hs.HybridUMATEmitter(exported).write("hybrid_umat_polyconvex.f90")
+```
+
+The Hessian for polyconvex models is block-diagonal (branches are independent), making the tangent computation more efficient.
+
+See `examples/train_polyconvex.py` for the complete runnable script.
 
 See also the runnable scripts in the [`examples/`](https://github.com/jpsferreira/hyper-surrogate/tree/main/examples) directory.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ Runnable scripts demonstrating the hyper-surrogate pipeline.
 | `train_icnn_energy.py`     | Train ICNN with `EnergyStressLoss` for convex energy               | `uv run python examples/train_icnn_energy.py`     |
 | `export_hybrid_umat.py`    | End-to-end train + `HybridUMATEmitter` export                      | `uv run python examples/export_hybrid_umat.py`    |
 | `train_holzapfel_ogden.py` | Anisotropic HolzapfelOgden with 5D invariants + hybrid UMAT        | `uv run python examples/train_holzapfel_ogden.py` |
+| `train_polyconvex.py`      | PolyconvexICNN with per-invariant branches + hybrid UMAT           | `uv run python examples/train_polyconvex.py`      |
 | `analytical_umat.py`       | Symbolic material to Fortran UMAT via `UMATHandler`                | `uv run python examples/analytical_umat.py`       |
 
 All examples follow the same structure: docstring, numbered sections, print statements for progress.

--- a/examples/train_polyconvex.py
+++ b/examples/train_polyconvex.py
@@ -1,0 +1,128 @@
+"""Train a PolyconvexICNN on a NeoHooke strain energy function.
+
+Demonstrates the polyconvex pipeline:
+1. Generate training data for NeoHooke material
+2. Train PolyconvexICNN with per-invariant ICNN branches
+3. Verify convexity guarantee
+4. Export to Fortran (FortranEmitter + HybridUMATEmitter)
+
+Usage:
+    uv run python examples/train_polyconvex.py
+"""
+
+import numpy as np
+import torch
+
+import hyper_surrogate as hs
+from hyper_surrogate.data.dataset import MaterialDataset, Normalizer
+from hyper_surrogate.data.deformation import DeformationGenerator
+from hyper_surrogate.mechanics.kinematics import Kinematics
+
+# ── 1. Material and deformation data ─────────────────────────────
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+n = 20000
+
+gen = DeformationGenerator(seed=42)
+F_base = gen.combined(n, stretch_range=(0.8, 1.3), shear_range=(-0.2, 0.2))
+
+rng = np.random.default_rng(99)
+J_target = rng.uniform(0.95, 1.05, size=n)
+J_current = np.linalg.det(F_base)
+F = F_base * (J_target / J_current)[:, None, None] ** (1.0 / 3.0)
+C = Kinematics.right_cauchy_green(F)
+
+# ── 2. Inputs and targets ────────────────────────────────────────
+i1 = Kinematics.isochoric_invariant1(C)
+i2 = Kinematics.isochoric_invariant2(C)
+j = np.sqrt(Kinematics.det_invariant(C))
+inputs = np.column_stack([i1, i2, j])
+
+energy = material.evaluate_energy(C)
+dW_dI = material.evaluate_energy_grad_invariants(C)
+
+print(f"Samples: {n}")
+print(f"I1=[{i1.min():.3f}, {i1.max():.3f}]")
+print(f"I2=[{i2.min():.3f}, {i2.max():.3f}]")
+print(f"J =[{j.min():.4f}, {j.max():.4f}]")
+
+# ── 3. Normalize and build datasets ──────────────────────────────
+in_norm = Normalizer().fit(inputs)
+X = in_norm.transform(inputs).astype(np.float32)
+W = energy.reshape(-1, 1).astype(np.float32)
+S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+n_val = int(n * 0.15)
+idx = np.random.default_rng(42).permutation(n)
+ti, vi = idx[n_val:], idx[:n_val]
+
+train_ds = MaterialDataset(X[ti], (W[ti], S[ti]))
+val_ds = MaterialDataset(X[vi], (W[vi], S[vi]))
+
+# ── 4. Train PolyconvexICNN ──────────────────────────────────────
+# Each invariant gets its own ICNN branch: W = W1(I1) + W2(I2) + W3(J)
+# Convexity per group is guaranteed by construction.
+model = hs.PolyconvexICNN(
+    groups=[[0], [1], [2]],
+    hidden_dims=[32, 32],
+    activation="softplus",
+)
+result = hs.Trainer(
+    model,
+    train_ds,
+    val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=3000,
+    lr=1e-3,
+    patience=300,
+    batch_size=512,
+).fit()
+
+best_val = result.history["val_loss"][result.best_epoch]
+print(f"\nBest val loss: {best_val:.6f} (epoch {result.best_epoch})")
+print(f"Total epochs: {len(result.history["train_loss"])}")
+
+# ── 5. Verify convexity ──────────────────────────────────────────
+print("\n── Convexity check ──")
+model.eval()
+x1 = torch.randn(1000, 3)
+x2 = torch.randn(1000, 3)
+lam = 0.5
+y_mid = model(lam * x1 + (1 - lam) * x2)
+y_conv = lam * model(x1) + (1 - lam) * model(x2)
+violations = (y_mid > y_conv + 1e-5).sum().item()
+print(f"  Convexity violations: {violations}/1000")
+
+# ── 6. Evaluate ──────────────────────────────────────────────────
+print("\n── Hybrid inference ──")
+test_idx = vi[:500]
+test_inp = inputs[test_idx]
+x = torch.tensor(in_norm.transform(test_inp).astype(np.float32), requires_grad=True)
+W_pred = model(x)
+dW_dx = torch.autograd.grad(W_pred.sum(), x, create_graph=True)[0]
+std_t = torch.tensor(in_norm.params["std"], dtype=torch.float32)
+dW_dI_pred = (dW_dx / std_t).detach().numpy()
+dW_dI_ref = dW_dI[test_idx]
+
+for i, name in enumerate(["dW/dI1_bar", "dW/dI2_bar", "dW/dJ"]):
+    ss_res = np.sum((dW_dI_pred[:, i] - dW_dI_ref[:, i]) ** 2)
+    ss_tot = np.sum((dW_dI_ref[:, i] - dW_dI_ref[:, i].mean()) ** 2)
+    r2 = 1 - ss_res / max(ss_tot, 1e-30)
+    print(f"  {name}: R²={r2:.6f}")
+
+# ── 7. Export ─────────────────────────────────────────────────────
+energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+exported = hs.extract_weights(result.model, in_norm, energy_norm)
+exported.save("polyconvex_neohooke.npz")
+
+# FortranEmitter (standalone NN module)
+emitter = hs.FortranEmitter(exported)
+emitter.write("nn_polyconvex.f90")
+
+# HybridUMATEmitter (full UMAT with analytical mechanics)
+hybrid = hs.HybridUMATEmitter(exported)
+hybrid.write("hybrid_umat_polyconvex.f90")
+
+print("\nExported:")
+print("  Weights:     polyconvex_neohooke.npz")
+print("  Fortran NN:  nn_polyconvex.f90")
+print("  Hybrid UMAT: hybrid_umat_polyconvex.f90")

--- a/hyper_surrogate/__init__.py
+++ b/hyper_surrogate/__init__.py
@@ -11,6 +11,7 @@ from hyper_surrogate.reporting.reporter import Reporter
 try:
     from hyper_surrogate.models.icnn import ICNN  # noqa: F401
     from hyper_surrogate.models.mlp import MLP  # noqa: F401
+    from hyper_surrogate.models.polyconvex import PolyconvexICNN  # noqa: F401
     from hyper_surrogate.training.losses import EnergyStressLoss, StressLoss, StressTangentLoss  # noqa: F401
     from hyper_surrogate.training.trainer import Trainer, TrainingResult  # noqa: F401
 except ImportError:

--- a/hyper_surrogate/export/fortran/emitter.py
+++ b/hyper_surrogate/export/fortran/emitter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 
@@ -194,12 +194,190 @@ class FortranEmitter:
 
         return "\n".join(lines)
 
+    def emit_polyconvex(self) -> str:
+        """Emit Fortran for PolyconvexICNN: per-branch forward + backward."""
+        meta = self.exported.metadata
+        in_dim = meta["input_dim"]
+        branches = meta.get("branches", [])
+
+        lines = ["MODULE nn_surrogate", "  IMPLICIT NONE", ""]
+
+        # Declare weight/bias arrays per branch
+        for bi, branch in enumerate(branches):
+            self._emit_poly_branch_weights(lines, bi, branch)
+
+        if self.exported.input_normalizer:
+            lines.append(self._format_array_1d(self.exported.input_normalizer["mean"], "in_mean"))
+            lines.append(self._format_array_1d(self.exported.input_normalizer["std"], "in_std"))
+
+        lines.extend(["", "CONTAINS", ""])
+
+        # Subroutine
+        lines.append("  SUBROUTINE nn_forward(input, energy, stress)")
+        lines.append(f"    DOUBLE PRECISION, INTENT(IN) :: input({in_dim})")
+        lines.append("    DOUBLE PRECISION, INTENT(OUT) :: energy")
+        lines.append(f"    DOUBLE PRECISION, INTENT(OUT) :: stress({in_dim})")
+        lines.append(f"    DOUBLE PRECISION :: x_norm({in_dim})")
+        lines.append("    DOUBLE PRECISION :: branch_energy")
+        lines.append("    INTEGER :: i, j")
+
+        # Declare branch-local arrays
+        for bi, branch in enumerate(branches):
+            self._emit_poly_branch_locals(lines, bi, branch)
+        lines.append("")
+
+        # Normalize
+        if self.exported.input_normalizer:
+            lines.append("    x_norm = (input - in_mean) / in_std")
+        else:
+            lines.append("    x_norm = input")
+        lines.append("")
+
+        lines.append("    energy = 0.0d0")
+        lines.append("    stress = 0.0d0")
+        lines.append("")
+
+        # Per-branch forward + backward
+        for bi, branch in enumerate(branches):
+            self._emit_poly_branch_body(lines, bi, branch)
+
+        lines.extend(["  END SUBROUTINE nn_forward", "", "END MODULE nn_surrogate"])
+        return "\n".join(lines)
+
+    def _emit_poly_branch_weights(self, lines: list[str], bi: int, branch: dict[str, Any]) -> None:
+        """Emit weight/bias parameter arrays for one polyconvex branch."""
+        weights = self.exported.weights
+        branch_layers = branch["layers"]
+        for li, layer in enumerate(branch_layers):
+            w = weights[layer["weights"]]
+            b = weights[layer["bias"]]
+            if "wz" in layer["weights"]:
+                w = np.log(1.0 + np.exp(w))
+            lines.append(self._format_array_2d(w, f"w_b{bi}_{li}"))
+            lines.append(self._format_array_1d(b, f"b_b{bi}_{li}"))
+        prefix = f"branches.{bi}."
+        wx_keys = sorted([
+            k
+            for k in weights
+            if k.startswith(prefix + "wx_layers") and "weight" in k and k != branch_layers[0]["weights"]
+        ])
+        for wi, wk in enumerate(wx_keys):
+            lines.append(self._format_array_2d(weights[wk], f"wx_b{bi}_{wi + 1}"))
+
+    def _emit_poly_branch_locals(self, lines: list[str], bi: int, branch: dict[str, Any]) -> None:
+        """Emit local variable declarations for one polyconvex branch."""
+        weights = self.exported.weights
+        branch_layers = branch["layers"]
+        b_in_dim = len(branch["input_indices"])
+        lines.append(f"    DOUBLE PRECISION :: x_b{bi}({b_in_dim})")
+        lines.append(f"    DOUBLE PRECISION :: grad_b{bi}({b_in_dim})")
+        for li, layer in enumerate(branch_layers[:-1]):
+            hd = weights[layer["weights"]].shape[0]
+            lines.append(f"    DOUBLE PRECISION :: z_b{bi}_{li}({hd})")
+            lines.append(f"    DOUBLE PRECISION :: dz_b{bi}_{li}({hd})")
+
+    def _emit_poly_branch_body(self, lines: list[str], bi: int, branch: dict[str, Any]) -> None:
+        """Emit forward + backward pass for one polyconvex branch."""
+        weights = self.exported.weights
+        branch_layers = branch["layers"]
+        indices = branch["input_indices"]
+        b_in_dim = len(indices)
+        n_hidden = len(branch_layers) - 1
+
+        lines.append(f"    ! === Branch {bi}: inputs [{", ".join(str(i + 1) for i in indices)}] ===")
+        for si, idx in enumerate(indices):
+            lines.append(f"    x_b{bi}({si + 1}) = x_norm({idx + 1})")
+        lines.append("")
+
+        # Forward pass
+        lines.append(f"    ! Forward pass branch {bi}")
+        lines.append(f"    z_b{bi}_0 = MATMUL(w_b{bi}_0, x_b{bi}) + b_b{bi}_0")
+        lines.extend(
+            "  " + line
+            for line in self._emit_activation(
+                f"z_b{bi}_0", branch_layers[0]["activation"], weights[branch_layers[0]["weights"]].shape[0]
+            )
+        )
+        lines.append("")
+
+        for li in range(1, n_hidden):
+            layer = branch_layers[li]
+            hd = weights[layer["weights"]].shape[0]
+            lines.append(
+                f"    z_b{bi}_{li} = MATMUL(w_b{bi}_{li}, z_b{bi}_{li - 1}) + MATMUL(wx_b{bi}_{li}, x_b{bi}) + b_b{bi}_{li}"
+            )
+            lines.extend("  " + line for line in self._emit_activation(f"z_b{bi}_{li}", layer["activation"], hd))
+            lines.append("")
+
+        last_li = len(branch_layers) - 1
+        lines.append(
+            f"    branch_energy = DOT_PRODUCT(w_b{bi}_{last_li}(1,:), z_b{bi}_{n_hidden - 1}) + b_b{bi}_{last_li}(1)"
+        )
+        lines.append("    energy = energy + branch_energy")
+        lines.append("")
+
+        # Backward pass
+        lines.append(f"    ! Backward pass branch {bi}")
+        lines.append(f"    dz_b{bi}_{n_hidden - 1} = w_b{bi}_{last_li}(1,:)")
+        lines.append("")
+
+        for li in range(n_hidden - 1, 0, -1):
+            layer = branch_layers[li]
+            hd = weights[layer["weights"]].shape[0]
+            self._emit_dact_multiply(lines, f"dz_b{bi}_{li}", f"z_b{bi}_{li}", layer["activation"], hd, bi, li)
+            prev_hd = weights[branch_layers[li - 1]["weights"]].shape[0]
+            lines.append(f"    DO i = 1, {prev_hd}")
+            lines.append(f"      dz_b{bi}_{li - 1}(i) = 0.0d0")
+            lines.append(f"      DO j = 1, {hd}")
+            lines.append(f"        dz_b{bi}_{li - 1}(i) = dz_b{bi}_{li - 1}(i) + w_b{bi}_{li}(j, i) * dz_b{bi}_{li}(j)")
+            lines.append("      END DO")
+            lines.append("    END DO")
+            lines.append("")
+
+        layer0 = branch_layers[0]
+        hd0 = weights[layer0["weights"]].shape[0]
+        self._emit_dact_multiply(lines, f"dz_b{bi}_0", f"z_b{bi}_0", layer0["activation"], hd0, bi, 0)
+
+        lines.append(f"    DO i = 1, {b_in_dim}")
+        lines.append(f"      grad_b{bi}(i) = 0.0d0")
+        lines.append(f"      DO j = 1, {hd0}")
+        lines.append(f"        grad_b{bi}(i) = grad_b{bi}(i) + w_b{bi}_0(j, i) * dz_b{bi}_0(j)")
+        lines.append("      END DO")
+        lines.append("    END DO")
+        lines.append("")
+
+        for si, idx in enumerate(indices):
+            lines.append(f"    stress({idx + 1}) = stress({idx + 1}) + grad_b{bi}({si + 1})")
+        lines.append("")
+
+    @staticmethod
+    def _emit_dact_multiply(
+        lines: list[str], dz_var: str, z_var: str, activation: str, size: int, bi: int, li: int
+    ) -> None:
+        """Multiply dz by activation derivative in-place."""
+        if activation == "identity":
+            return
+        if activation == "softplus":
+            lines.append(f"    DO i = 1, {size}")
+            lines.append(f"      {dz_var}(i) = {dz_var}(i) / (1.0d0 + exp(-{z_var}(i)))")
+            lines.append("    END DO")
+        elif activation == "tanh":
+            lines.append(f"    DO i = 1, {size}")
+            lines.append(f"      {dz_var}(i) = {dz_var}(i) * (1.0d0 - {z_var}(i)**2)")
+            lines.append("    END DO")
+        elif activation == "relu":
+            lines.append(f"    DO i = 1, {size}")
+            lines.append(f"      IF ({z_var}(i) <= 0.0d0) {dz_var}(i) = 0.0d0")
+            lines.append("    END DO")
+
     def emit(self) -> str:
         arch = self.exported.metadata.get("architecture", "mlp")
         if arch == "mlp":
             return self.emit_mlp()
         elif arch == "icnn":
             return self.emit_icnn()
+        elif arch == "polyconvexicnn":
+            return self.emit_polyconvex()
         else:
             msg = f"Unknown architecture: {arch}"
             raise ValueError(msg)

--- a/hyper_surrogate/export/fortran/hybrid.py
+++ b/hyper_surrogate/export/fortran/hybrid.py
@@ -24,9 +24,12 @@ from hyper_surrogate.export.weights import ExportedModel
 class HybridUMATEmitter:
     """Emit a complete Abaqus UMAT subroutine with NN-based strain energy."""
 
+    SUPPORTED_ARCHITECTURES = ("mlp", "polyconvexicnn")
+
     def __init__(self, exported: ExportedModel) -> None:
-        if exported.metadata.get("architecture") != "mlp":
-            msg = "HybridUMATEmitter only supports MLP architecture"
+        arch = exported.metadata.get("architecture")
+        if arch not in self.SUPPORTED_ARCHITECTURES:
+            msg = f"HybridUMATEmitter supports {self.SUPPORTED_ARCHITECTURES}, got '{arch}'"
             raise ValueError(msg)
         if exported.metadata.get("output_dim") != 1:
             msg = "HybridUMATEmitter requires a scalar (output_dim=1) energy model"
@@ -60,6 +63,13 @@ class HybridUMATEmitter:
 
     def _emit_nn_parameters(self) -> str:
         """Emit weight/bias arrays and normalizer constants."""
+        arch = self.exported.metadata.get("architecture")
+        if arch == "polyconvexicnn":
+            return self._emit_poly_nn_parameters()
+        return self._emit_mlp_nn_parameters()
+
+    def _emit_mlp_nn_parameters(self) -> str:
+        """Emit MLP weight/bias arrays."""
         lines: list[str] = []
         layers = self.exported.layers
         weights = self.exported.weights
@@ -76,8 +86,48 @@ class HybridUMATEmitter:
 
         return "\n".join(lines)
 
+    def _emit_poly_nn_parameters(self) -> str:
+        """Emit per-branch ICNN weight/bias arrays."""
+        lines: list[str] = []
+        weights = self.exported.weights
+        branches = self.exported.metadata["branches"]
+
+        for bi, branch in enumerate(branches):
+            branch_layers = branch["layers"]
+            for li, layer in enumerate(branch_layers):
+                w = weights[layer["weights"]]
+                b = weights[layer["bias"]]
+                # Pre-apply softplus to wz weights (non-negative constraint)
+                if "wz" in layer["weights"]:
+                    w = np.log(1.0 + np.exp(w))
+                lines.append(self._fmt_2d(w, f"w_b{bi}_{li}"))
+                lines.append(self._fmt_1d(b, f"b_b{bi}_{li}"))
+
+            # wx skip-connection weights (layers 1..L-1 have wx_layers)
+            prefix = f"branches.{bi}."
+            wx_keys = sorted([
+                k
+                for k in weights
+                if k.startswith(prefix + "wx_layers") and "weight" in k and k != branch_layers[0]["weights"]
+            ])
+            for wi, wk in enumerate(wx_keys):
+                lines.append(self._fmt_2d(weights[wk], f"wx_b{bi}_{wi + 1}"))
+            # wx_final skip
+            wx_final_key = prefix + "wx_final.weight"
+            if wx_final_key in weights:
+                lines.append(self._fmt_2d(weights[wx_final_key], f"wxf_b{bi}"))
+
+        if self.exported.input_normalizer:
+            lines.append(self._fmt_1d(self.exported.input_normalizer["mean"], "in_mean"))
+            lines.append(self._fmt_1d(self.exported.input_normalizer["std"], "in_std"))
+
+        return "\n".join(lines)
+
     def _emit_nn_forward_and_backward(self) -> str:  # noqa: C901
         """Emit NN forward pass + analytical backward pass for dW/dI and d²W/dI²."""
+        arch = self.exported.metadata.get("architecture")
+        if arch == "polyconvexicnn":
+            return self._emit_poly_nn_forward_and_backward()
         layers = self.exported.layers
         weights = self.exported.weights
         n_layers = len(layers)
@@ -349,6 +399,210 @@ class HybridUMATEmitter:
       END DO
     END DO
 """
+
+    def _emit_poly_nn_forward_and_backward(self) -> str:  # noqa: C901
+        """Emit polyconvex ICNN forward/backward with per-branch Hessian."""
+        weights = self.exported.weights
+        branches = self.exported.metadata["branches"]
+        in_dim = self.exported.metadata["input_dim"]
+
+        lines: list[str] = []
+
+        # Local variables
+        lines.append(f"DOUBLE PRECISION :: x_norm({in_dim})")
+        for bi, branch in enumerate(branches):
+            b_layers = branch["layers"]
+            b_in = len(branch["input_indices"])
+            n_hidden = len(b_layers) - 1
+            lines.append(f"DOUBLE PRECISION :: xb{bi}({b_in})")
+            for li in range(n_hidden):
+                hd = weights[b_layers[li]["weights"]].shape[0]
+                lines.append(f"DOUBLE PRECISION :: z_b{bi}_{li}({hd})")
+                lines.append(f"DOUBLE PRECISION :: a_b{bi}_{li}({hd})")
+                lines.append(f"DOUBLE PRECISION :: dact_b{bi}_{li}({hd})")
+                lines.append(f"DOUBLE PRECISION :: d2act_b{bi}_{li}({hd})")
+                lines.append(f"DOUBLE PRECISION :: delta_b{bi}_{li}({hd})")
+                lines.append(f"DOUBLE PRECISION :: P_b{bi}_{li}({hd},{b_in})")
+                lines.append(f"DOUBLE PRECISION :: J_b{bi}_{li}({hd},{b_in})")
+            lines.append(f"DOUBLE PRECISION :: grad_b{bi}({b_in})")
+            lines.append(f"DOUBLE PRECISION :: d2W_b{bi}({b_in},{b_in})")
+        lines.append("DOUBLE PRECISION :: coeff, branch_W")
+        lines.append("")
+
+        # Normalize input
+        lines.append("! Normalize invariants")
+        lines.append("x_norm = (nn_input - in_mean) / in_std")
+        lines.append("")
+
+        # Initialize outputs
+        lines.append("W_nn = 0.0d0")
+        lines.append("dW_dI = 0.0d0")
+        lines.append("d2W_dI2 = 0.0d0")
+        lines.append("")
+
+        # Per-branch forward + backward + Hessian
+        for bi, branch in enumerate(branches):
+            b_layers = branch["layers"]
+            indices = branch["input_indices"]
+            b_in = len(indices)
+            n_hidden = len(b_layers) - 1
+
+            lines.append(f"! ---- Branch {bi}: inputs [{", ".join(str(i + 1) for i in indices)}] ----")
+
+            # Slice input
+            for si, idx in enumerate(indices):
+                lines.append(f"xb{bi}({si + 1}) = x_norm({idx + 1})")
+            lines.append("")
+
+            # Forward pass
+            lines.append(f"! Forward pass branch {bi}")
+            # Layer 0: x-path only
+            lines.append(f"a_b{bi}_0 = MATMUL(w_b{bi}_0, xb{bi}) + b_b{bi}_0")
+            act0 = b_layers[0]["activation"]
+            hd0 = weights[b_layers[0]["weights"]].shape[0]
+            self._emit_icnn_act(lines, bi, 0, act0, hd0)
+            lines.append("")
+
+            # Hidden layers with wz + wx skip
+            for li in range(1, n_hidden):
+                layer = b_layers[li]
+                hd = weights[layer["weights"]].shape[0]
+                act = layer["activation"]
+                lines.append(
+                    f"a_b{bi}_{li} = MATMUL(w_b{bi}_{li}, z_b{bi}_{li - 1}) + MATMUL(wx_b{bi}_{li}, xb{bi}) + b_b{bi}_{li}"
+                )
+                self._emit_icnn_act(lines, bi, li, act, hd)
+                lines.append("")
+
+            # Output: identity activation
+            last_li = len(b_layers) - 1
+            last_hidden = n_hidden - 1
+            lines.append(
+                f"branch_W = DOT_PRODUCT(w_b{bi}_{last_li}(1,:), z_b{bi}_{last_hidden}) + DOT_PRODUCT(wxf_b{bi}(1,:), xb{bi}) + b_b{bi}_{last_li}(1)"
+            )
+            lines.append("W_nn = W_nn + branch_W")
+            lines.append("")
+
+            # Backward pass
+            lines.append(f"! Backward pass branch {bi}")
+            # delta for last hidden layer
+            hd_last = weights[b_layers[last_hidden]["weights"]].shape[0]
+            lines.append(f"DO ii = 1, {hd_last}")
+            lines.append(f"  delta_b{bi}_{last_hidden}(ii) = w_b{bi}_{last_li}(1, ii) * dact_b{bi}_{last_hidden}(ii)")
+            lines.append("END DO")
+
+            # Backprop through hidden layers
+            for li in range(last_hidden - 1, -1, -1):
+                hd = weights[b_layers[li]["weights"]].shape[0]
+                hd_next = weights[b_layers[li + 1]["weights"]].shape[0]
+                lines.append(f"DO ii = 1, {hd}")
+                lines.append(f"  delta_b{bi}_{li}(ii) = 0.0d0")
+                lines.append(f"  DO jj = 1, {hd_next}")
+                lines.append(
+                    f"    delta_b{bi}_{li}(ii) = delta_b{bi}_{li}(ii) + w_b{bi}_{li + 1}(jj, ii) * delta_b{bi}_{li + 1}(jj)"
+                )
+                lines.append("  END DO")
+                lines.append(f"  delta_b{bi}_{li}(ii) = delta_b{bi}_{li}(ii) * dact_b{bi}_{li}(ii)")
+                lines.append("END DO")
+
+            # grad_b = W0^T * delta_0 + wx_final^T
+            lines.append(f"DO ii = 1, {b_in}")
+            lines.append(f"  grad_b{bi}(ii) = wxf_b{bi}(1, ii)")
+            lines.append(f"  DO jj = 1, {hd0}")
+            lines.append(f"    grad_b{bi}(ii) = grad_b{bi}(ii) + w_b{bi}_0(jj, ii) * delta_b{bi}_0(jj)")
+            lines.append("  END DO")
+            lines.append("END DO")
+            lines.append("")
+
+            # Scatter gradient
+            for si, idx in enumerate(indices):
+                lines.append(f"dW_dI({idx + 1}) = dW_dI({idx + 1}) + grad_b{bi}({si + 1}) / in_std({idx + 1})")
+            lines.append("")
+
+            # Jacobian propagation for Hessian
+            lines.append(f"! Jacobian propagation branch {bi}")
+            # P0 = W0, J0 = diag(dact0) * W0
+            lines.append(f"DO ii = 1, {hd0}")
+            lines.append(f"  DO jj = 1, {b_in}")
+            lines.append(f"    P_b{bi}_0(ii, jj) = w_b{bi}_0(ii, jj)")
+            lines.append(f"    J_b{bi}_0(ii, jj) = dact_b{bi}_0(ii) * w_b{bi}_0(ii, jj)")
+            lines.append("  END DO")
+            lines.append("END DO")
+
+            for li in range(1, n_hidden):
+                hd = weights[b_layers[li]["weights"]].shape[0]
+                hd_prev = weights[b_layers[li - 1]["weights"]].shape[0]
+                # P_i = Wz_i * J_{i-1} + Wx_i  (ICNN skip connection)
+                lines.append(f"DO ii = 1, {hd}")
+                lines.append(f"  DO jj = 1, {b_in}")
+                lines.append(f"    P_b{bi}_{li}(ii, jj) = wx_b{bi}_{li}(ii, jj)")
+                lines.append(f"    DO kk = 1, {hd_prev}")
+                lines.append(
+                    f"      P_b{bi}_{li}(ii, jj) = P_b{bi}_{li}(ii, jj) + w_b{bi}_{li}(ii, kk) * J_b{bi}_{li - 1}(kk, jj)"
+                )
+                lines.append("    END DO")
+                lines.append(f"    J_b{bi}_{li}(ii, jj) = dact_b{bi}_{li}(ii) * P_b{bi}_{li}(ii, jj)")
+                lines.append("  END DO")
+                lines.append("END DO")
+            lines.append("")
+
+            # Hessian: d2W_b = sum_i P_i^T diag(beta_i * d2act_i) P_i
+            lines.append(f"! Hessian branch {bi}")
+            lines.append(f"d2W_b{bi} = 0.0d0")
+            for li in range(n_hidden):
+                act = b_layers[li]["activation"]
+                if act in ("relu", "identity"):
+                    lines.append(f"! Layer {li} ({act}): d2act=0, skip")
+                    continue
+                hd = weights[b_layers[li]["weights"]].shape[0]
+                lines.append(f"DO ii = 1, {hd}")
+                lines.append(f"  coeff = delta_b{bi}_{li}(ii) / dact_b{bi}_{li}(ii) * d2act_b{bi}_{li}(ii)")
+                lines.append(f"  DO jj = 1, {b_in}")
+                lines.append(f"    DO kk = 1, {b_in}")
+                lines.append(
+                    f"      d2W_b{bi}(jj, kk) = d2W_b{bi}(jj, kk) + coeff * P_b{bi}_{li}(ii, jj) * P_b{bi}_{li}(ii, kk)"
+                )
+                lines.append("    END DO")
+                lines.append("  END DO")
+                lines.append("END DO")
+            lines.append("")
+
+            # Scatter Hessian (block-diagonal)
+            for si, idx_i in enumerate(indices):
+                for sj, idx_j in enumerate(indices):
+                    lines.append(
+                        f"d2W_dI2({idx_i + 1},{idx_j + 1}) = d2W_dI2({idx_i + 1},{idx_j + 1})"
+                        f" + d2W_b{bi}({si + 1},{sj + 1}) / (in_std({idx_i + 1}) * in_std({idx_j + 1}))"
+                    )
+            lines.append("")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _emit_icnn_act(lines: list[str], bi: int, li: int, act: str, hd: int) -> None:
+        """Emit activation + dact + d2act for ICNN branch layer."""
+        if act == "identity":
+            lines.append(f"z_b{bi}_{li} = a_b{bi}_{li}")
+            lines.append(f"dact_b{bi}_{li} = 1.0d0")
+            lines.append(f"d2act_b{bi}_{li} = 0.0d0")
+        elif act == "softplus":
+            lines.append(f"z_b{bi}_{li} = log(1.0d0 + exp(a_b{bi}_{li}))")
+            lines.append(f"dact_b{bi}_{li} = 1.0d0 / (1.0d0 + exp(-a_b{bi}_{li}))")
+            lines.append(f"d2act_b{bi}_{li} = dact_b{bi}_{li} * (1.0d0 - dact_b{bi}_{li})")
+        elif act == "tanh":
+            lines.append(f"z_b{bi}_{li} = tanh(a_b{bi}_{li})")
+            lines.append(f"dact_b{bi}_{li} = 1.0d0 - z_b{bi}_{li}**2")
+            lines.append(f"d2act_b{bi}_{li} = -2.0d0 * z_b{bi}_{li} * dact_b{bi}_{li}")
+        elif act == "relu":
+            lines.append(f"DO ii = 1, {hd}")
+            lines.append(f"  z_b{bi}_{li}(ii) = max(0.0d0, a_b{bi}_{li}(ii))")
+            lines.append(f"  IF (a_b{bi}_{li}(ii) > 0.0d0) THEN")
+            lines.append(f"    dact_b{bi}_{li}(ii) = 1.0d0")
+            lines.append("  ELSE")
+            lines.append(f"    dact_b{bi}_{li}(ii) = 0.0d0")
+            lines.append("  END IF")
+            lines.append(f"  d2act_b{bi}_{li}(ii) = 0.0d0")
+            lines.append("END DO")
 
     def emit(self) -> str:
         """Generate the complete hybrid UMAT Fortran code."""

--- a/hyper_surrogate/export/weights.py
+++ b/hyper_surrogate/export/weights.py
@@ -66,14 +66,26 @@ def extract_weights(
     if not isinstance(model, SurrogateModel):
         msg = f"Expected SurrogateModel, got {type(model)}"
         raise TypeError(msg)
+    metadata: dict[str, Any] = {
+        "architecture": model.__class__.__name__.lower(),
+        "input_dim": model.input_dim,
+        "output_dim": model.output_dim,
+    }
+
+    branches = model.branch_sequence()
+    if branches is not None:
+        metadata["branches"] = [
+            {"name": b.name, "input_indices": b.input_indices, "layers": _layers_to_dicts(b.layers)} for b in branches
+        ]
+
     return ExportedModel(
         layers=model.layer_sequence(),
         weights=model.export_weights(),
         input_normalizer=input_normalizer.params if input_normalizer else None,
         output_normalizer=output_normalizer.params if output_normalizer else None,
-        metadata={
-            "architecture": model.__class__.__name__.lower(),
-            "input_dim": model.input_dim,
-            "output_dim": model.output_dim,
-        },
+        metadata=metadata,
     )
+
+
+def _layers_to_dicts(layers: list[Any]) -> list[dict[str, str]]:
+    return [{"weights": ly.weights, "bias": ly.bias, "activation": ly.activation} for ly in layers]

--- a/hyper_surrogate/models/__init__.py
+++ b/hyper_surrogate/models/__init__.py
@@ -1,7 +1,8 @@
 try:
     from hyper_surrogate.models.icnn import ICNN
     from hyper_surrogate.models.mlp import MLP
+    from hyper_surrogate.models.polyconvex import PolyconvexICNN
 
-    __all__ = ["MLP", "ICNN"]
+    __all__ = ["MLP", "ICNN", "PolyconvexICNN"]
 except ImportError:
     __all__ = []

--- a/hyper_surrogate/models/base.py
+++ b/hyper_surrogate/models/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import numpy as np
 import torch.nn as nn
@@ -12,6 +12,15 @@ class LayerInfo:
     weights: str
     bias: str
     activation: str
+
+
+@dataclass
+class BranchInfo:
+    """Describes one branch of a multi-branch model (e.g. PolyconvexICNN)."""
+
+    name: str
+    input_indices: list[int]
+    layers: list[LayerInfo] = field(default_factory=list)
 
 
 class SurrogateModel(nn.Module, ABC):
@@ -25,6 +34,10 @@ class SurrogateModel(nn.Module, ABC):
 
     @abstractmethod
     def layer_sequence(self) -> list[LayerInfo]: ...
+
+    def branch_sequence(self) -> list[BranchInfo] | None:
+        """Return branch info for multi-branch models. None for single-branch."""
+        return None
 
     def export_weights(self) -> dict[str, np.ndarray]:
         return {k: v.detach().cpu().numpy() for k, v in self.state_dict().items()}

--- a/hyper_surrogate/models/polyconvex.py
+++ b/hyper_surrogate/models/polyconvex.py
@@ -1,0 +1,100 @@
+"""Polyconvex ICNN: multi-branch input-convex network preserving polyconvexity.
+
+Each branch is an independent ICNN operating on a group of invariants.
+The total energy is the sum of branch outputs — convex superposition
+preserves convexity per group.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from hyper_surrogate.models.base import BranchInfo, LayerInfo, SurrogateModel
+from hyper_surrogate.models.icnn import ICNN
+
+
+class PolyconvexICNN(SurrogateModel):
+    """Multi-branch ICNN for polyconvex strain energy.
+
+    Args:
+        groups: List of input index lists, e.g. ``[[0], [1], [2]]`` for
+            isotropic or ``[[0], [1], [2], [3, 4]]`` for anisotropic.
+            Each group feeds a separate ICNN branch.
+        hidden_dims: Hidden layer sizes for each branch ICNN.
+        activation: Activation function for all branches.
+    """
+
+    def __init__(
+        self,
+        groups: list[list[int]],
+        hidden_dims: list[int] | None = None,
+        activation: str = "softplus",
+    ) -> None:
+        super().__init__()
+        if hidden_dims is None:
+            hidden_dims = [32, 32]
+
+        all_indices = [idx for g in groups for idx in g]
+        if len(all_indices) != len(set(all_indices)):
+            msg = "Input indices must not overlap across groups"
+            raise ValueError(msg)
+
+        self._groups = groups
+        self._input_dim = max(all_indices) + 1
+        self._hidden_dims = hidden_dims
+        self._activation_name = activation
+
+        self.branches = nn.ModuleList([
+            ICNN(input_dim=len(g), hidden_dims=hidden_dims, activation=activation) for g in groups
+        ])
+
+    @property
+    def input_dim(self) -> int:
+        return self._input_dim
+
+    @property
+    def output_dim(self) -> int:
+        return 1
+
+    @property
+    def groups(self) -> list[list[int]]:
+        return self._groups
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        total = torch.zeros(x.shape[0], 1, device=x.device, dtype=x.dtype)
+        for branch, group in zip(self.branches, self._groups, strict=True):
+            x_branch = x[:, group]
+            total = total + branch(x_branch)
+        return total
+
+    def layer_sequence(self) -> list[LayerInfo]:
+        """Return layers from the first branch (backward compat)."""
+        return self._branch_layers(0)
+
+    def branch_sequence(self) -> list[BranchInfo]:
+        """Return BranchInfo per branch with prefixed weight keys."""
+        result = []
+        for i, group in enumerate(self._groups):
+            result.append(
+                BranchInfo(
+                    name=f"branch_{i}",
+                    input_indices=group,
+                    layers=self._branch_layers(i),
+                )
+            )
+        return result
+
+    def _branch_layers(self, branch_idx: int) -> list[LayerInfo]:
+        """Get LayerInfo for a specific branch with prefixed keys."""
+        prefix = f"branches.{branch_idx}."
+        branch: ICNN = self.branches[branch_idx]  # type: ignore[assignment]
+        raw_layers = branch.layer_sequence()
+        return [
+            LayerInfo(
+                weights=prefix + layer.weights,
+                bias=prefix + layer.bias,
+                activation=layer.activation,
+            )
+            for layer in raw_layers
+        ]

--- a/tests/test_holzapfel_ogden.py
+++ b/tests/test_holzapfel_ogden.py
@@ -1,23 +1,45 @@
 """Tests for HolzapfelOgden transversely isotropic material."""
 
 import numpy as np
+import pytest
+from sympy import Symbol
 
 from hyper_surrogate.mechanics.kinematics import Kinematics
-from hyper_surrogate.mechanics.materials import HolzapfelOgden
+from hyper_surrogate.mechanics.materials import HolzapfelOgden, MooneyRivlin, NeoHooke
 
 
 def _identity_batch(n=1):
     return np.tile(np.eye(3), (n, 1, 1))
 
 
-def test_energy_at_identity_is_zero():
-    """Strain energy at identity deformation should be zero."""
-    mat = HolzapfelOgden()
-    C = _identity_batch()
-    grad = mat.evaluate_energy_grad_invariants(C)
-    # At identity: I1_bar=3, I4=1 -> both exponent terms are 0 -> W=0
-    # The grad should exist and have shape (1, 5)
-    assert grad.shape == (1, 5)
+def _uniaxial_F(stretch, axis=0, n=1):
+    """Incompressible uniaxial stretch along a given axis."""
+    F = np.tile(np.eye(3), (n, 1, 1))
+    lateral = 1.0 / np.sqrt(stretch)
+    F[:, 0, 0] = lateral
+    F[:, 1, 1] = lateral
+    F[:, 2, 2] = lateral
+    F[:, axis, axis] = stretch
+    return F
+
+
+def _evaluate_energy_from_invariants(mat, i1_bar, i2_bar, j, i4=None, i5=None):
+    """Numerically evaluate SEF via sef_from_invariants."""
+    from sympy import lambdify
+
+    syms_inv = [Symbol("I1b"), Symbol("I2b"), Symbol("J")]
+    if i4 is not None:
+        syms_inv += [Symbol("I4"), Symbol("I5")]
+    W_expr = mat.sef_from_invariants(*syms_inv[:3], *syms_inv[3:] if len(syms_inv) > 3 else [])
+    param_syms = list(mat._symbols.values())
+    fn = lambdify((*syms_inv, *param_syms), W_expr, modules="numpy")
+    param_vals = list(mat._params.values())
+    if i4 is not None:
+        return fn(i1_bar, i2_bar, j, i4, i5, *param_vals)
+    return fn(i1_bar, i2_bar, j, *param_vals)
+
+
+# ── Properties ────────────────────────────────────────────────────
 
 
 def test_is_anisotropic():
@@ -27,42 +49,368 @@ def test_is_anisotropic():
     np.testing.assert_allclose(mat.fiber_direction, [1, 0, 0])
 
 
-def test_grad_shape_is_5d():
-    """Energy gradient should return (N, 5) for anisotropic material."""
+def test_default_parameters():
     mat = HolzapfelOgden()
-    n = 10
-    F = np.tile(np.eye(3), (n, 1, 1))
-    # Small perturbation to avoid singularities
-    F[:, 0, 0] = np.linspace(0.95, 1.05, n)
-    F[:, 1, 1] = 1.0 / np.sqrt(F[:, 0, 0])
-    F[:, 2, 2] = 1.0 / np.sqrt(F[:, 0, 0])
-    C = Kinematics.right_cauchy_green(F)
-    grad = mat.evaluate_energy_grad_invariants(C)
-    assert grad.shape == (n, 5)
+    assert mat._params["a"] == 0.059
+    assert mat._params["b"] == 8.023
+    assert mat._params["af"] == 18.472
+    assert mat._params["bf"] == 16.026
+    assert mat._params["KBULK"] == 1000.0
+
+
+def test_custom_parameters():
+    custom = {"a": 0.1, "b": 10.0, "af": 20.0, "bf": 15.0, "KBULK": 500.0}
+    mat = HolzapfelOgden(parameters=custom)
+    for k, v in custom.items():
+        assert mat._params[k] == v
 
 
 def test_fiber_direction_custom():
-    """Custom fiber direction should be stored correctly."""
     a0 = np.array([0.0, 1.0, 0.0])
     mat = HolzapfelOgden(fiber_direction=a0)
     np.testing.assert_allclose(mat.fiber_direction, a0)
 
 
-def test_isotropic_materials_not_anisotropic():
-    """NeoHooke and MooneyRivlin should NOT be anisotropic."""
-    from hyper_surrogate.mechanics.materials import MooneyRivlin, NeoHooke
+def test_fiber_direction_normalized_storage():
+    """Fiber direction is stored as-is (user responsibility to normalize)."""
+    a0 = np.array([0.0, 0.0, 1.0])
+    mat = HolzapfelOgden(fiber_direction=a0)
+    np.testing.assert_allclose(mat.fiber_direction, a0)
 
+
+def test_isotropic_materials_not_anisotropic():
     assert not NeoHooke().is_anisotropic
     assert not MooneyRivlin().is_anisotropic
 
 
 def test_neohooke_grad_still_3d():
-    """NeoHooke should still return (N, 3) gradients."""
-    from hyper_surrogate.mechanics.materials import NeoHooke
-
     mat = NeoHooke()
-    C = _identity_batch(5) * 1.01  # slight perturbation
-    # Make symmetric
+    C = _identity_batch(5) * 1.01
     C = np.einsum("nij->nji", C) * 0.5 + C * 0.5
     grad = mat.evaluate_energy_grad_invariants(C)
     assert grad.shape == (5, 3)
+
+
+# ── SEF property raises NotImplementedError ───────────────────────
+
+
+def test_sef_raises():
+    """HolzapfelOgden.sef must raise (requires fiber invariants)."""
+    mat = HolzapfelOgden()
+    with pytest.raises(NotImplementedError, match="fiber"):
+        _ = mat.sef
+
+
+# ── Energy at identity ────────────────────────────────────────────
+
+
+def test_energy_at_identity_is_zero():
+    """At identity: I1_bar=3, I4=1, J=1 -> W=0."""
+    mat = HolzapfelOgden()
+    W = _evaluate_energy_from_invariants(mat, 3.0, 3.0, 1.0, 1.0, 1.0)
+    np.testing.assert_allclose(W, 0.0, atol=1e-14)
+
+
+def test_energy_at_identity_via_invariants():
+    """Compute invariants from identity C and verify energy=0."""
+    mat = HolzapfelOgden()
+    C = _identity_batch()
+    a0 = mat.fiber_direction
+    i1 = Kinematics.isochoric_invariant1(C)
+    i2 = Kinematics.isochoric_invariant2(C)
+    j = np.sqrt(Kinematics.det_invariant(C))
+    i4 = Kinematics.fiber_invariant4(C, a0)
+    i5 = Kinematics.fiber_invariant5(C, a0)
+    W = _evaluate_energy_from_invariants(mat, i1[0], i2[0], j[0], i4[0], i5[0])
+    np.testing.assert_allclose(float(W), 0.0, atol=1e-14)
+
+
+# ── Energy values ─────────────────────────────────────────────────
+
+
+def test_energy_positive_under_stretch():
+    """Energy should be positive for any non-trivial deformation."""
+    mat = HolzapfelOgden()
+    F = _uniaxial_F(1.1, axis=0)
+    C = Kinematics.right_cauchy_green(F)
+    a0 = mat.fiber_direction
+    i1 = Kinematics.isochoric_invariant1(C)[0]
+    i2 = Kinematics.isochoric_invariant2(C)[0]
+    j = np.sqrt(Kinematics.det_invariant(C))[0]
+    i4 = Kinematics.fiber_invariant4(C, a0)[0]
+    i5 = Kinematics.fiber_invariant5(C, a0)[0]
+    W = float(_evaluate_energy_from_invariants(mat, i1, i2, j, i4, i5))
+    assert W > 0
+
+
+def test_energy_isotropic_part_matches_neohooke():
+    """When af=0, HolzapfelOgden isotropic part should match scaled exponential form."""
+    # With af=0, fiber contribution vanishes
+    mat = HolzapfelOgden(parameters={"a": 0.059, "b": 8.023, "af": 0.0, "bf": 16.026, "KBULK": 1000.0})
+    i1_bar, j = 3.2, 1.0
+    W = float(_evaluate_energy_from_invariants(mat, i1_bar, 3.0, j, 1.0, 1.0))
+    # Manual: (a/2b)(exp(b*(I1_bar-3))-1) + vol(J=1)=0
+    a, b = 0.059, 8.023
+    expected = (a / (2 * b)) * (np.exp(b * (i1_bar - 3)) - 1)
+    np.testing.assert_allclose(W, expected, rtol=1e-10)
+
+
+def test_energy_fiber_part_only():
+    """With a=0 and KBULK=0, only fiber term remains."""
+    mat = HolzapfelOgden(parameters={"a": 0.0, "b": 8.023, "af": 18.472, "bf": 16.026, "KBULK": 0.0})
+    i4 = 1.2  # Fiber in tension
+    W = float(_evaluate_energy_from_invariants(mat, 3.0, 3.0, 1.0, i4, 1.0))
+    af, bf = 18.472, 16.026
+    expected = (af / (2 * bf)) * (np.exp(bf * (i4 - 1) ** 2) - 1)
+    np.testing.assert_allclose(W, expected, rtol=1e-10)
+
+
+def test_energy_volumetric_part_only():
+    """With a=0, af=0: only volumetric term remains."""
+    mat = HolzapfelOgden(parameters={"a": 0.0, "b": 8.023, "af": 0.0, "bf": 16.026, "KBULK": 1000.0})
+    j = 1.05
+    W = float(_evaluate_energy_from_invariants(mat, 3.0, 3.0, j, 1.0, 1.0))
+    # vol(J) = KBULK/4 * (J^2 - 1 - 2*ln(J))
+    KBULK = 1000.0
+    expected = 0.25 * KBULK * (j**2 - 1 - 2 * np.log(j))
+    np.testing.assert_allclose(W, expected, rtol=1e-10)
+
+
+# ── Macaulay bracket (fiber tension vs compression) ───────────────
+
+
+def test_fiber_active_only_in_tension():
+    """Fiber contribution should be zero when I4 < 1 (compression).
+
+    Note: The symbolic SEF does not implement the Macaulay bracket —
+    this is applied numerically during evaluation. This test documents
+    the raw symbolic behavior where (I4-1)^2 > 0 even in compression.
+    """
+    mat = HolzapfelOgden(parameters={"a": 0.0, "b": 1.0, "af": 18.472, "bf": 16.026, "KBULK": 0.0})
+    # I4 < 1: fiber in compression
+    W_compression = float(_evaluate_energy_from_invariants(mat, 3.0, 3.0, 1.0, 0.8, 1.0))
+    # I4 > 1: fiber in tension
+    W_tension = float(_evaluate_energy_from_invariants(mat, 3.0, 3.0, 1.0, 1.2, 1.0))
+    # Both should be positive in the raw symbolic form (no Macaulay bracket at symbolic level)
+    assert W_compression > 0
+    assert W_tension > 0
+
+
+def test_fiber_energy_symmetric_around_i4_one():
+    """(I4-1)^2 is symmetric, so W(I4=0.8) == W(I4=1.2) when only fiber term active."""
+    mat = HolzapfelOgden(parameters={"a": 0.0, "b": 1.0, "af": 18.472, "bf": 16.026, "KBULK": 0.0})
+    W_a = float(_evaluate_energy_from_invariants(mat, 3.0, 3.0, 1.0, 0.8, 1.0))
+    W_b = float(_evaluate_energy_from_invariants(mat, 3.0, 3.0, 1.0, 1.2, 1.0))
+    np.testing.assert_allclose(W_a, W_b, rtol=1e-12)
+
+
+# ── Gradient shape and values ─────────────────────────────────────
+
+
+def test_grad_shape_is_5d():
+    mat = HolzapfelOgden()
+    n = 10
+    F = _uniaxial_F(1.05, axis=0, n=n)
+    C = Kinematics.right_cauchy_green(F)
+    grad = mat.evaluate_energy_grad_invariants(C)
+    assert grad.shape == (n, 5)
+
+
+def test_grad_at_identity():
+    """At identity: dW/dI1_bar = a/2 * exp(0) = a/2, dW/dI4 = 0 (I4=1)."""
+    mat = HolzapfelOgden()
+    C = _identity_batch()
+    grad = mat.evaluate_energy_grad_invariants(C)
+    a = mat._params["a"]
+    # dW/dI1_bar = (a/2) at I1_bar=3
+    np.testing.assert_allclose(grad[0, 0], a / 2.0, rtol=1e-10)
+    # dW/dI2_bar = 0 (no I2 dependence)
+    np.testing.assert_allclose(grad[0, 1], 0.0, atol=1e-14)
+    # dW/dJ at J=1: vol'(1) = KBULK/2 * (J - 1/J) = 0
+    np.testing.assert_allclose(grad[0, 2], 0.0, atol=1e-14)
+    # dW/dI4 at I4=1: af*(I4-1)*exp(bf*(I4-1)^2) = 0
+    np.testing.assert_allclose(grad[0, 3], 0.0, atol=1e-14)
+    # dW/dI5 = 0 (no I5 dependence in this model)
+    np.testing.assert_allclose(grad[0, 4], 0.0, atol=1e-14)
+
+
+def test_grad_finite_difference():
+    """Verify analytical gradient against finite differences of energy."""
+    mat = HolzapfelOgden()
+    # Use a deformed state
+    F = _uniaxial_F(1.1, axis=0)
+    C = Kinematics.right_cauchy_green(F)
+    a0 = mat.fiber_direction
+
+    i1 = float(Kinematics.isochoric_invariant1(C)[0])
+    i2 = float(Kinematics.isochoric_invariant2(C)[0])
+    j = float(np.sqrt(Kinematics.det_invariant(C)[0]))
+    i4 = float(Kinematics.fiber_invariant4(C, a0)[0])
+    i5 = float(Kinematics.fiber_invariant5(C, a0)[0])
+
+    inv_vals = [i1, i2, j, i4, i5]
+    grad_analytical = mat.evaluate_energy_grad_invariants(C)[0]
+
+    eps = 1e-7
+    grad_fd = np.zeros(5)
+    for k in range(5):
+        inv_p = list(inv_vals)
+        inv_m = list(inv_vals)
+        inv_p[k] += eps
+        inv_m[k] -= eps
+        W_p = float(_evaluate_energy_from_invariants(mat, *inv_p))
+        W_m = float(_evaluate_energy_from_invariants(mat, *inv_m))
+        grad_fd[k] = (W_p - W_m) / (2 * eps)
+
+    np.testing.assert_allclose(grad_analytical, grad_fd, rtol=1e-5, atol=1e-10)
+
+
+def test_grad_nonzero_fiber_under_stretch():
+    """dW/dI4 should be nonzero when fiber is stretched (I4 > 1)."""
+    mat = HolzapfelOgden()
+    F = _uniaxial_F(1.15, axis=0)  # stretch along fiber direction
+    C = Kinematics.right_cauchy_green(F)
+    grad = mat.evaluate_energy_grad_invariants(C)
+    assert grad[0, 3] != 0.0  # dW/dI4 nonzero
+
+
+def test_grad_dw_di5_always_zero():
+    """This HolzapfelOgden model has no I5 dependence, so dW/dI5=0 always."""
+    mat = HolzapfelOgden()
+    F = _uniaxial_F(1.2, axis=0, n=5)
+    C = Kinematics.right_cauchy_green(F)
+    grad = mat.evaluate_energy_grad_invariants(C)
+    np.testing.assert_allclose(grad[:, 4], 0.0, atol=1e-14)
+
+
+# ── Multiple deformation states ──────────────────────────────────
+
+
+def test_uniaxial_along_fiber():
+    """Uniaxial stretch along fiber direction should activate both isotropic and fiber."""
+    mat = HolzapfelOgden()
+    F = _uniaxial_F(1.2, axis=0)  # fiber along x
+    C = Kinematics.right_cauchy_green(F)
+    a0 = mat.fiber_direction
+    i4 = Kinematics.fiber_invariant4(C, a0)[0]
+    assert i4 > 1.0  # Fiber in tension
+    grad = mat.evaluate_energy_grad_invariants(C)
+    assert grad[0, 0] > 0  # dW/dI1_bar > 0
+    assert grad[0, 3] > 0  # dW/dI4 > 0
+
+
+def test_uniaxial_transverse_to_fiber():
+    """Stretch transverse to fiber should not stretch the fiber (I4 < 1)."""
+    mat = HolzapfelOgden()
+    F = _uniaxial_F(1.2, axis=1)  # stretch along y, fiber along x
+    C = Kinematics.right_cauchy_green(F)
+    a0 = mat.fiber_direction
+    i4 = Kinematics.fiber_invariant4(C, a0)[0]
+    # Transverse stretch compresses the fiber direction
+    assert i4 < 1.0
+
+
+def test_shear_deformation():
+    """Simple shear should produce valid gradients."""
+    mat = HolzapfelOgden()
+    n = 5
+    F = np.tile(np.eye(3), (n, 1, 1))
+    F[:, 0, 1] = np.linspace(0.05, 0.25, n)  # shear in xy
+    C = Kinematics.right_cauchy_green(F)
+    grad = mat.evaluate_energy_grad_invariants(C)
+    assert grad.shape == (n, 5)
+    # All finite
+    assert np.all(np.isfinite(grad))
+
+
+def test_multiple_stretch_levels():
+    """Energy should increase monotonically with uniaxial stretch along fiber."""
+    mat = HolzapfelOgden()
+    a0 = mat.fiber_direction
+    stretches = np.array([1.01, 1.05, 1.1, 1.15, 1.2])
+    energies = []
+    for s in stretches:
+        F = _uniaxial_F(s, axis=0)
+        C = Kinematics.right_cauchy_green(F)
+        i1 = float(Kinematics.isochoric_invariant1(C)[0])
+        i2 = float(Kinematics.isochoric_invariant2(C)[0])
+        j = float(np.sqrt(Kinematics.det_invariant(C)[0]))
+        i4 = float(Kinematics.fiber_invariant4(C, a0)[0])
+        i5 = float(Kinematics.fiber_invariant5(C, a0)[0])
+        W = float(_evaluate_energy_from_invariants(mat, i1, i2, j, i4, i5))
+        energies.append(W)
+    # Strictly increasing
+    for k in range(len(energies) - 1):
+        assert energies[k + 1] > energies[k], f"Energy not increasing at stretch {stretches[k + 1]}"
+
+
+# ── Fiber direction dependence ────────────────────────────────────
+
+
+def test_fiber_direction_affects_energy():
+    """Same deformation, different fiber direction should give different energy."""
+    mat_x = HolzapfelOgden(fiber_direction=np.array([1.0, 0.0, 0.0]))
+    mat_y = HolzapfelOgden(fiber_direction=np.array([0.0, 1.0, 0.0]))
+
+    F = _uniaxial_F(1.15, axis=0)
+    C = Kinematics.right_cauchy_green(F)
+
+    def _energy(mat):
+        a0 = mat.fiber_direction
+        i1 = float(Kinematics.isochoric_invariant1(C)[0])
+        i2 = float(Kinematics.isochoric_invariant2(C)[0])
+        j = float(np.sqrt(Kinematics.det_invariant(C)[0]))
+        i4 = float(Kinematics.fiber_invariant4(C, a0)[0])
+        i5 = float(Kinematics.fiber_invariant5(C, a0)[0])
+        return float(_evaluate_energy_from_invariants(mat, i1, i2, j, i4, i5))
+
+    W_x = _energy(mat_x)
+    W_y = _energy(mat_y)
+    # x-fiber is stretched, y-fiber is compressed: different energies
+    assert W_x != W_y
+    # x-fiber should have higher energy (stretched along fiber)
+    assert W_x > W_y
+
+
+# ── sef_from_invariants symbolic ──────────────────────────────────
+
+
+def test_sef_from_invariants_symbolic():
+    """sef_from_invariants should return a sympy expression."""
+    mat = HolzapfelOgden()
+    i1, i2, j, i4, i5 = (Symbol(s) for s in ["I1b", "I2b", "J", "I4", "I5"])
+    W = mat.sef_from_invariants(i1, i2, j, i4, i5)
+    assert W is not None
+    # Should contain all parameter symbols
+    free = W.free_symbols
+    assert Symbol("a") in free
+    assert Symbol("b") in free
+    assert Symbol("af") in free
+    assert Symbol("bf") in free
+    assert Symbol("KBULK") in free
+
+
+def test_sef_from_invariants_no_i4_gives_isotropic_only():
+    """Without I4, fiber term should vanish."""
+    mat = HolzapfelOgden()
+    i1, i2, j = (Symbol(s) for s in ["I1b", "I2b", "J"])
+    W = mat.sef_from_invariants(i1, i2, j)
+    # Should not contain af, bf (fiber parameters only appear with I4)
+    free = W.free_symbols
+    # The expression should still be defined (isotropic + volumetric)
+    assert Symbol("a") in free
+    assert Symbol("KBULK") in free
+
+
+# ── Batch consistency ─────────────────────────────────────────────
+
+
+def test_batch_gradient_consistency():
+    """Gradient for batch of identical deformations should be identical."""
+    mat = HolzapfelOgden()
+    F_single = _uniaxial_F(1.1, axis=0)
+    F_batch = np.tile(F_single, (5, 1, 1))
+    C = Kinematics.right_cauchy_green(F_batch)
+    grad = mat.evaluate_energy_grad_invariants(C)
+    for i in range(1, 5):
+        np.testing.assert_allclose(grad[i], grad[0], rtol=1e-12)

--- a/tests/test_hybrid_emitter.py
+++ b/tests/test_hybrid_emitter.py
@@ -18,10 +18,10 @@ def _make_scalar_model(activation="softplus", hidden_dims=None, input_dim=3):
     return extract_weights(model, in_norm, energy_norm)
 
 
-def test_rejects_non_mlp():
+def test_rejects_unsupported_architecture():
     exported = _make_scalar_model()
     exported.metadata["architecture"] = "icnn"
-    with pytest.raises(ValueError, match="only supports MLP"):
+    with pytest.raises(ValueError, match="supports"):
         HybridUMATEmitter(exported)
 
 

--- a/tests/test_models_polyconvex.py
+++ b/tests/test_models_polyconvex.py
@@ -1,0 +1,180 @@
+"""Tests for PolyconvexICNN model."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+from hyper_surrogate.data.dataset import Normalizer  # noqa: E402
+from hyper_surrogate.export.fortran.emitter import FortranEmitter  # noqa: E402
+from hyper_surrogate.export.fortran.hybrid import HybridUMATEmitter  # noqa: E402
+from hyper_surrogate.export.weights import extract_weights  # noqa: E402
+from hyper_surrogate.models.polyconvex import PolyconvexICNN  # noqa: E402
+
+
+def test_forward_shape():
+    model = PolyconvexICNN(groups=[[0], [1], [2]], hidden_dims=[8, 8])
+    x = torch.randn(10, 3)
+    y = model(x)
+    assert y.shape == (10, 1)
+
+
+def test_forward_shape_aniso():
+    model = PolyconvexICNN(groups=[[0], [1], [2], [3, 4]], hidden_dims=[8, 8])
+    x = torch.randn(10, 5)
+    y = model(x)
+    assert y.shape == (10, 1)
+
+
+def test_input_output_dim():
+    model = PolyconvexICNN(groups=[[0], [1], [2]])
+    assert model.input_dim == 3
+    assert model.output_dim == 1
+
+
+def test_overlapping_groups_rejected():
+    with pytest.raises(ValueError, match="overlap"):
+        PolyconvexICNN(groups=[[0, 1], [1, 2]])
+
+
+def test_groups_property():
+    groups = [[0], [1], [2], [3, 4]]
+    model = PolyconvexICNN(groups=groups)
+    assert model.groups == groups
+
+
+def test_per_branch_convexity():
+    """Each branch should be convex (Jensen's inequality)."""
+    model = PolyconvexICNN(groups=[[0], [1], [2]], hidden_dims=[16, 16])
+    model.eval()
+
+    x1 = torch.randn(50, 3)
+    x2 = torch.randn(50, 3)
+    lam = 0.3
+
+    y_mid = model(lam * x1 + (1 - lam) * x2)
+    y_conv = lam * model(x1) + (1 - lam) * model(x2)
+
+    # Convex: f(lam*x1 + (1-lam)*x2) <= lam*f(x1) + (1-lam)*f(x2)
+    assert (y_mid <= y_conv + 1e-5).all(), "Convexity violated"
+
+
+def test_gradient_exists():
+    model = PolyconvexICNN(groups=[[0], [1], [2]])
+    x = torch.randn(5, 3, requires_grad=True)
+    y = model(x)
+    y.sum().backward()
+    assert x.grad is not None
+    assert x.grad.shape == (5, 3)
+
+
+def test_branch_sequence():
+    model = PolyconvexICNN(groups=[[0], [1], [2]])
+    branches = model.branch_sequence()
+    assert branches is not None
+    assert len(branches) == 3
+    assert branches[0].name == "branch_0"
+    assert branches[0].input_indices == [0]
+    assert branches[2].input_indices == [2]
+    # Each branch should have layers with prefixed weight keys
+    for b in branches:
+        for layer in b.layers:
+            assert layer.weights.startswith(f"branches.{b.name[-1]}.")
+
+
+def test_layer_sequence():
+    """layer_sequence returns first branch layers (backward compat)."""
+    model = PolyconvexICNN(groups=[[0], [1], [2]])
+    layers = model.layer_sequence()
+    assert len(layers) > 0
+    assert all(ly.weights.startswith("branches.0.") for ly in layers)
+
+
+def test_export_weights():
+    model = PolyconvexICNN(groups=[[0], [1], [2]], hidden_dims=[8])
+    in_norm = Normalizer().fit(np.random.randn(50, 3))
+    exported = extract_weights(model, in_norm)
+    assert exported.metadata["architecture"] == "polyconvexicnn"
+    assert exported.metadata["input_dim"] == 3
+    assert exported.metadata["output_dim"] == 1
+    assert "branches" in exported.metadata
+    assert len(exported.metadata["branches"]) == 3
+
+
+def test_export_save_load(tmp_path):
+    model = PolyconvexICNN(groups=[[0], [1], [2]], hidden_dims=[8])
+    in_norm = Normalizer().fit(np.random.randn(50, 3))
+    exported = extract_weights(model, in_norm)
+    path = tmp_path / "poly.npz"
+    exported.save(str(path))
+    loaded = type(exported).load(str(path))
+    assert loaded.metadata["branches"] == exported.metadata["branches"]
+    assert loaded.metadata["architecture"] == "polyconvexicnn"
+
+
+def test_fortran_emitter_polyconvex():
+    model = PolyconvexICNN(groups=[[0], [1], [2]], hidden_dims=[8, 8])
+    in_norm = Normalizer().fit(np.random.randn(50, 3))
+    exported = extract_weights(model, in_norm)
+    code = FortranEmitter(exported).emit()
+    assert "MODULE nn_surrogate" in code
+    assert "Branch 0" in code
+    assert "Branch 1" in code
+    assert "Branch 2" in code
+    assert "grad_b0" in code
+    assert "stress" in code
+
+
+def test_hybrid_umat_polyconvex():
+    model = PolyconvexICNN(groups=[[0], [1], [2]], hidden_dims=[8, 8])
+    in_norm = Normalizer().fit(np.random.randn(50, 3))
+    energy_norm = Normalizer().fit(np.random.randn(50, 1))
+    exported = extract_weights(model, in_norm, energy_norm)
+    code = HybridUMATEmitter(exported).emit()
+    assert "MODULE nn_sef" in code
+    assert "SUBROUTINE nn_eval" in code
+    assert "SUBROUTINE umat" in code
+    # Per-branch forward/backward
+    assert "Branch 0" in code
+    assert "Hessian branch" in code
+    # Block-diagonal scatter
+    assert "d2W_dI2" in code
+
+
+def test_hybrid_umat_polyconvex_aniso():
+    """Anisotropic polyconvex UMAT (in_dim=5)."""
+    model = PolyconvexICNN(groups=[[0], [1], [2], [3, 4]], hidden_dims=[8, 8])
+    in_norm = Normalizer().fit(np.random.randn(50, 5))
+    energy_norm = Normalizer().fit(np.random.randn(50, 1))
+    exported = extract_weights(model, in_norm, energy_norm)
+    code = HybridUMATEmitter(exported).emit()
+    assert "nn_input(5)" in code
+    assert "dW_dI(5)" in code
+    assert "d2W_dI2(5,5)" in code
+    assert "I4" in code
+    assert "Branch 3" in code
+
+
+def test_training_with_energy_stress_loss():
+    """PolyconvexICNN can be trained with EnergyStressLoss."""
+    from hyper_surrogate.data.dataset import MaterialDataset
+    from hyper_surrogate.training.losses import EnergyStressLoss
+    from hyper_surrogate.training.trainer import Trainer
+
+    model = PolyconvexICNN(groups=[[0], [1], [2]], hidden_dims=[8, 8])
+    n = 100
+    X = np.random.randn(n, 3).astype(np.float32)
+    W = np.random.randn(n, 1).astype(np.float32)
+    S = np.random.randn(n, 3).astype(np.float32)
+
+    train_ds = MaterialDataset(X[:80], (W[:80], S[:80]))
+    val_ds = MaterialDataset(X[80:], (W[80:], S[80:]))
+
+    result = Trainer(
+        model,
+        train_ds,
+        val_ds,
+        loss_fn=EnergyStressLoss(alpha=1.0, beta=1.0),
+        max_epochs=5,
+        lr=1e-3,
+    ).fit()
+    assert len(result.history["train_loss"]) == 5


### PR DESCRIPTION
## Summary
- Add `PolyconvexICNN` model: independent ICNN branches per invariant group, convex superposition guarantees polyconvexity
- Add `BranchInfo` dataclass and `branch_sequence()` to `SurrogateModel` base
- Extend `extract_weights` to store branch metadata for multi-branch models
- Add `FortranEmitter.emit_polyconvex()` with per-branch forward + backward pass
- Extend `HybridUMATEmitter` for `polyconvexicnn` architecture: per-branch ICNN forward/backward, analytical Hessian (block-diagonal), scatter into full gradient/Hessian
- Add `examples/train_polyconvex.py` and docs

## Files changed
- `hyper_surrogate/models/base.py` — BranchInfo, branch_sequence()
- `hyper_surrogate/models/polyconvex.py` — PolyconvexICNN (new)
- `hyper_surrogate/export/weights.py` — branch metadata in extract_weights
- `hyper_surrogate/export/fortran/emitter.py` — emit_polyconvex()
- `hyper_surrogate/export/fortran/hybrid.py` — polyconvexicnn support in HybridUMATEmitter
- `hyper_surrogate/models/__init__.py`, `hyper_surrogate/__init__.py` — registration
- `tests/test_models_polyconvex.py` — 15 new tests
- `tests/test_hybrid_emitter.py` — updated architecture rejection test
- `examples/train_polyconvex.py`, `examples/README.md`, `docs/examples.md` — example + docs

## Test plan
- [x] `make check` passes (ruff, mypy, deptry)
- [x] `make test` passes (156 tests, 0 failures)
- [x] Per-branch convexity verified via Jensen's inequality test
- [ ] Run `examples/train_polyconvex.py` end-to-end
- [ ] Review generated Fortran for ICNN backward pass correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)