### PR TITLE
Fix I2_bar bug and add deep test coverage

### DIFF
--- a/hyper_surrogate/mechanics/symbolic.py
+++ b/hyper_surrogate/mechanics/symbolic.py
@@ -89,14 +89,13 @@ class SymbolicHandler:
     def isochoric_invariant2(self) -> Expr:
         """
         Compute the second isochoric invariant of the c_tensor.
-        I2 = 1/2 * (I1^2 - trace(c_tensor^2))
+        I2_bar = 1/2 * (I1^2 - trace(C^2)) * J^{-4/3}
 
         Returns:
             Expr: The second isochoric invariant of the c_tensor.
         """
-        return (Rational(1, 2) * (self.isochoric_invariant1**2 - self._c_tensor_squared().trace())) * (
-            self.invariant3 ** (-Rational(2, 3))
-        )
+        i1 = self.c_tensor.trace()
+        return Rational(1, 2) * (i1**2 - self._c_tensor_squared().trace()) * (self.invariant3 ** (-Rational(2, 3)))
 
     @property
     def invariant3(self) -> Expr:

--- a/tests/test_integration_e2e.py
+++ b/tests/test_integration_e2e.py
@@ -1,0 +1,380 @@
+"""End-to-end integration tests.
+
+Train a model, export weights, generate Fortran, and verify the NN forward
+pass matches PyTorch numerically by reimplementing in numpy.
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+from hyper_surrogate.data.dataset import MaterialDataset, Normalizer  # noqa: E402
+from hyper_surrogate.export.fortran.emitter import FortranEmitter  # noqa: E402
+from hyper_surrogate.export.fortran.hybrid import HybridUMATEmitter  # noqa: E402
+from hyper_surrogate.export.weights import ExportedModel, extract_weights  # noqa: E402
+from hyper_surrogate.mechanics.kinematics import Kinematics  # noqa: E402
+from hyper_surrogate.mechanics.materials import NeoHooke  # noqa: E402
+from hyper_surrogate.models.icnn import ICNN  # noqa: E402
+from hyper_surrogate.models.mlp import MLP  # noqa: E402
+from hyper_surrogate.training.losses import EnergyStressLoss, StressLoss  # noqa: E402
+from hyper_surrogate.training.trainer import Trainer  # noqa: E402
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+
+def _numpy_forward_mlp(x, exported, activation="softplus"):
+    """Reimplement MLP forward pass in numpy to validate against PyTorch."""
+    act_fn = {
+        "softplus": lambda a: np.log1p(np.exp(a)),
+        "tanh": np.tanh,
+        "relu": lambda a: np.maximum(0, a),
+        "sigmoid": lambda a: 1.0 / (1.0 + np.exp(-a)),
+    }[activation]
+
+    # Normalize input
+    if exported.input_normalizer:
+        x = (x - exported.input_normalizer["mean"]) / exported.input_normalizer["std"]
+
+    z = x
+    for _i, layer in enumerate(exported.layers):
+        W = exported.weights[layer.weights]
+        b = exported.weights[layer.bias] if layer.bias else np.zeros(W.shape[0])
+        z = z @ W.T + b
+        if layer.activation != "identity":
+            z = act_fn(z)
+
+    # Denormalize output
+    if exported.output_normalizer:
+        z = z * exported.output_normalizer["std"] + exported.output_normalizer["mean"]
+    return z
+
+
+def _numpy_forward_icnn(x, exported, activation="softplus"):
+    """Reimplement ICNN forward pass in numpy."""
+    act_fn = {
+        "softplus": lambda a: np.log1p(np.exp(a)),
+        "relu": lambda a: np.maximum(0, a),
+        "tanh": np.tanh,
+    }[activation]
+
+    x_input = x.copy()
+    if exported.input_normalizer:
+        x_input = (x_input - exported.input_normalizer["mean"]) / exported.input_normalizer["std"]
+
+    weights = exported.weights
+    layers = exported.layers
+
+    # First layer: z = act(wx_0 @ x + bx_0)
+    wx0 = weights[layers[0].weights]
+    bx0 = weights[layers[0].bias]
+    z = act_fn(x_input @ wx0.T + bx0)
+
+    # Hidden layers: z = act(softplus(wz) @ z + wx @ x + bx)
+    for layer in layers[1:-1]:
+        wz_raw = weights[layer.weights]
+        bx = weights[layer.bias]
+        # Find corresponding wx layer
+        # wx key: replace wz_layers with wx_layers, increment index by 1
+        layer_idx = int(layer.weights.split(".")[1])
+        wx_key = f"wx_layers.{layer_idx + 1}.weight"
+        wx = weights[wx_key]
+        wz = np.log1p(np.exp(wz_raw))  # softplus clamping
+        z = act_fn(z @ wz.T + x_input @ wx.T + bx)
+
+    # Output layer: softplus(wz_final) @ z + wx_final @ x + bx_final
+    wz_final = weights[layers[-1].weights]
+    bx_final = weights[layers[-1].bias]
+    wx_final_key = "wx_final.weight"
+    wx_final = weights[wx_final_key]
+    wz_clamped = np.log1p(np.exp(wz_final))
+    z = z @ wz_clamped.T + x_input @ wx_final.T + bx_final
+
+    if exported.output_normalizer:
+        z = z * exported.output_normalizer["std"] + exported.output_normalizer["mean"]
+    return z
+
+
+def _generate_training_data(n=500, seed=42):
+    """Generate NeoHooke training data for integration tests."""
+    material = NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+    from hyper_surrogate.data.deformation import DeformationGenerator
+
+    gen = DeformationGenerator(seed=seed)
+    F = gen.combined(n, stretch_range=(0.85, 1.2), shear_range=(-0.15, 0.15))
+    rng = np.random.default_rng(99)
+    J_target = rng.uniform(0.97, 1.03, size=n)
+    J_current = np.linalg.det(F)
+    F = F * (J_target / J_current)[:, None, None] ** (1.0 / 3.0)
+    C = Kinematics.right_cauchy_green(F)
+
+    i1 = Kinematics.isochoric_invariant1(C)
+    i2 = Kinematics.isochoric_invariant2(C)
+    j = np.sqrt(Kinematics.det_invariant(C))
+    inputs = np.column_stack([i1, i2, j])
+
+    energy = material.evaluate_energy(C)
+    dW_dI = material.evaluate_energy_grad_invariants(C)
+
+    return inputs, energy, dW_dI
+
+
+# ── MLP end-to-end ────────────────────────────────────────────────
+
+
+def test_mlp_train_export_numpy_match():
+    """Train MLP, export, verify numpy forward pass matches PyTorch."""
+    inputs, energy, dW_dI = _generate_training_data(n=300)
+
+    in_norm = Normalizer().fit(inputs)
+    X = in_norm.transform(inputs).astype(np.float32)
+    W = energy.reshape(-1, 1).astype(np.float32)
+    S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+    n_val = 50
+    idx = np.random.default_rng(42).permutation(len(X))
+    train_ds = MaterialDataset(X[idx[n_val:]], (W[idx[n_val:]], S[idx[n_val:]]))
+    val_ds = MaterialDataset(X[idx[:n_val]], (W[idx[:n_val]], S[idx[:n_val]]))
+
+    model = MLP(input_dim=3, output_dim=1, hidden_dims=[16, 16], activation="softplus")
+    result = Trainer(
+        model,
+        train_ds,
+        val_ds,
+        loss_fn=EnergyStressLoss(alpha=1.0, beta=1.0),
+        max_epochs=50,
+        lr=1e-3,
+        batch_size=128,
+    ).fit()
+
+    energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+    exported = extract_weights(result.model, in_norm, energy_norm)
+
+    # Test on a few points
+    test_inputs = inputs[idx[:10]]
+    model.eval()
+    x_torch = torch.tensor(in_norm.transform(test_inputs).astype(np.float32))
+    with torch.no_grad():
+        y_torch = model(x_torch).numpy()
+    y_torch_denorm = y_torch * energy_norm.params["std"] + energy_norm.params["mean"]
+
+    y_numpy = _numpy_forward_mlp(test_inputs, exported)
+
+    np.testing.assert_allclose(y_numpy, y_torch_denorm, rtol=1e-5)
+
+
+def test_mlp_stress_train_export():
+    """Train MLP on PK2 stress, verify export and numpy match."""
+    inputs, _, dW_dI = _generate_training_data(n=200)
+
+    in_norm = Normalizer().fit(inputs)
+    out_norm = Normalizer().fit(dW_dI)
+    X = in_norm.transform(inputs).astype(np.float32)
+    Y = out_norm.transform(dW_dI).astype(np.float32)
+
+    n_val = 30
+    idx = np.random.default_rng(42).permutation(len(X))
+    train_ds = MaterialDataset(X[idx[n_val:]], Y[idx[n_val:]])
+    val_ds = MaterialDataset(X[idx[:n_val]], Y[idx[:n_val]])
+
+    model = MLP(input_dim=3, output_dim=3, hidden_dims=[16, 16], activation="tanh")
+    result = Trainer(
+        model,
+        train_ds,
+        val_ds,
+        loss_fn=StressLoss(),
+        max_epochs=30,
+        lr=1e-3,
+    ).fit()
+
+    exported = extract_weights(result.model, in_norm, out_norm)
+    test_inputs = inputs[idx[:5]]
+
+    model.eval()
+    x_torch = torch.tensor(in_norm.transform(test_inputs).astype(np.float32))
+    with torch.no_grad():
+        y_torch = model(x_torch).numpy()
+    y_torch_denorm = y_torch * out_norm.params["std"] + out_norm.params["mean"]
+
+    y_numpy = _numpy_forward_mlp(test_inputs, exported, activation="tanh")
+    np.testing.assert_allclose(y_numpy, y_torch_denorm, rtol=1e-4)
+
+
+# ── ICNN end-to-end ───────────────────────────────────────────────
+
+
+def test_icnn_train_export_numpy_match():
+    """Train ICNN, export, verify numpy forward pass matches PyTorch."""
+    inputs, energy, dW_dI = _generate_training_data(n=300)
+
+    in_norm = Normalizer().fit(inputs)
+    X = in_norm.transform(inputs).astype(np.float32)
+    W = energy.reshape(-1, 1).astype(np.float32)
+    S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+    n_val = 50
+    idx = np.random.default_rng(42).permutation(len(X))
+    train_ds = MaterialDataset(X[idx[n_val:]], (W[idx[n_val:]], S[idx[n_val:]]))
+    val_ds = MaterialDataset(X[idx[:n_val]], (W[idx[:n_val]], S[idx[:n_val]]))
+
+    model = ICNN(input_dim=3, hidden_dims=[16, 16], activation="softplus")
+    result = Trainer(
+        model,
+        train_ds,
+        val_ds,
+        loss_fn=EnergyStressLoss(alpha=1.0, beta=1.0),
+        max_epochs=50,
+        lr=1e-3,
+        batch_size=128,
+    ).fit()
+
+    energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+    exported = extract_weights(result.model, in_norm, energy_norm)
+
+    test_inputs = inputs[idx[:10]]
+    model.eval()
+    x_torch = torch.tensor(in_norm.transform(test_inputs).astype(np.float32))
+    with torch.no_grad():
+        y_torch = model(x_torch).numpy()
+    y_torch_denorm = y_torch * energy_norm.params["std"] + energy_norm.params["mean"]
+
+    y_numpy = _numpy_forward_icnn(test_inputs, exported)
+    np.testing.assert_allclose(y_numpy, y_torch_denorm, rtol=1e-5)
+
+
+# ── Export + Fortran generation ───────────────────────────────────
+
+
+def test_mlp_export_generates_valid_fortran():
+    """Full pipeline: train -> export -> FortranEmitter produces valid code."""
+    inputs, energy, dW_dI = _generate_training_data(n=100)
+
+    in_norm = Normalizer().fit(inputs)
+    X = in_norm.transform(inputs).astype(np.float32)
+    W = energy.reshape(-1, 1).astype(np.float32)
+    S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+    train_ds = MaterialDataset(X[:80], (W[:80], S[:80]))
+    val_ds = MaterialDataset(X[80:], (W[80:], S[80:]))
+
+    model = MLP(input_dim=3, output_dim=1, hidden_dims=[8, 8], activation="softplus")
+    result = Trainer(
+        model,
+        train_ds,
+        val_ds,
+        loss_fn=EnergyStressLoss(alpha=1.0, beta=1.0),
+        max_epochs=5,
+        lr=1e-3,
+    ).fit()
+
+    energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+    exported = extract_weights(result.model, in_norm, energy_norm)
+    code = FortranEmitter(exported).emit()
+
+    assert "MODULE nn_surrogate" in code
+    assert "SUBROUTINE nn_forward" in code
+    assert "w0" in code
+    assert "in_mean" in code
+
+
+def test_mlp_export_generates_valid_hybrid_umat():
+    """Full pipeline: train -> export -> HybridUMATEmitter produces valid UMAT."""
+    inputs, energy, dW_dI = _generate_training_data(n=100)
+
+    in_norm = Normalizer().fit(inputs)
+    X = in_norm.transform(inputs).astype(np.float32)
+    W = energy.reshape(-1, 1).astype(np.float32)
+    S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+    train_ds = MaterialDataset(X[:80], (W[:80], S[:80]))
+    val_ds = MaterialDataset(X[80:], (W[80:], S[80:]))
+
+    model = MLP(input_dim=3, output_dim=1, hidden_dims=[8, 8], activation="softplus")
+    result = Trainer(
+        model,
+        train_ds,
+        val_ds,
+        loss_fn=EnergyStressLoss(alpha=1.0, beta=1.0),
+        max_epochs=5,
+        lr=1e-3,
+    ).fit()
+
+    energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+    exported = extract_weights(result.model, in_norm, energy_norm)
+    code = HybridUMATEmitter(exported).emit()
+
+    assert "MODULE nn_sef" in code
+    assert "SUBROUTINE nn_eval" in code
+    assert "SUBROUTINE umat" in code
+    assert "d2W_dI2" in code
+    assert "Cauchy" in code
+
+
+def test_hybrid_umat_write_file(tmp_path):
+    """Full pipeline including file write."""
+    inputs, energy, dW_dI = _generate_training_data(n=100)
+
+    in_norm = Normalizer().fit(inputs)
+    energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+    X = in_norm.transform(inputs).astype(np.float32)
+    W = energy.reshape(-1, 1).astype(np.float32)
+    S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+    train_ds = MaterialDataset(X[:80], (W[:80], S[:80]))
+    val_ds = MaterialDataset(X[80:], (W[80:], S[80:]))
+
+    model = MLP(input_dim=3, output_dim=1, hidden_dims=[8], activation="softplus")
+    result = Trainer(
+        model,
+        train_ds,
+        val_ds,
+        loss_fn=EnergyStressLoss(alpha=1.0, beta=1.0),
+        max_epochs=3,
+        lr=1e-3,
+    ).fit()
+
+    exported = extract_weights(result.model, in_norm, energy_norm)
+
+    # Write both files
+    f90_path = tmp_path / "nn_surrogate.f90"
+    umat_path = tmp_path / "hybrid_umat.f90"
+    npz_path = tmp_path / "weights.npz"
+
+    FortranEmitter(exported).write(str(f90_path))
+    HybridUMATEmitter(exported).write(str(umat_path))
+    exported.save(str(npz_path))
+
+    assert f90_path.exists()
+    assert umat_path.exists()
+    assert npz_path.exists()
+
+    # Verify roundtrip
+    loaded = ExportedModel.load(str(npz_path))
+    assert loaded.metadata["architecture"] == "mlp"
+    for k in exported.weights:
+        np.testing.assert_array_equal(exported.weights[k], loaded.weights[k])
+
+
+# ── Save/load preserves predictions ──────────────────────────────
+
+
+def test_save_load_predictions_match():
+    """Export, save, load, and verify numpy predictions are identical."""
+    inputs, energy, _ = _generate_training_data(n=50)
+
+    in_norm = Normalizer().fit(inputs)
+    energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+
+    model = MLP(input_dim=3, output_dim=1, hidden_dims=[8, 8], activation="softplus")
+    exported = extract_weights(model, in_norm, energy_norm)
+
+    y_before = _numpy_forward_mlp(inputs[:5], exported)
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        path = f"{td}/model.npz"
+        exported.save(path)
+        loaded = ExportedModel.load(path)
+
+    y_after = _numpy_forward_mlp(inputs[:5], loaded)
+    np.testing.assert_array_equal(y_before, y_after)

--- a/tests/test_models_icnn_deep.py
+++ b/tests/test_models_icnn_deep.py
@@ -1,0 +1,241 @@
+"""Deep tests for ICNN model: Hessian PSD, activations, export, training, Fortran."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+from hyper_surrogate.data.dataset import Normalizer  # noqa: E402
+from hyper_surrogate.export.weights import ExportedModel, extract_weights  # noqa: E402
+from hyper_surrogate.models.icnn import ICNN  # noqa: E402
+
+# ── Convexity (multiple t values) ────────────────────────────────
+
+
+@pytest.mark.parametrize("t", [0.1, 0.3, 0.5, 0.7, 0.9])
+def test_convexity_multiple_t(t):
+    """Jensen's inequality for multiple interpolation values."""
+    model = ICNN(input_dim=3, hidden_dims=[32, 32])
+    model.eval()
+    x1 = torch.randn(100, 3)
+    x2 = torch.randn(100, 3)
+    with torch.no_grad():
+        f_mix = model(t * x1 + (1 - t) * x2)
+        f_avg = t * model(x1) + (1 - t) * model(x2)
+    assert (f_mix <= f_avg + 1e-5).all(), f"Convexity violated at t={t}"
+
+
+# ── Hessian PSD ──────────────────────────────────────────────────
+
+
+def test_hessian_psd():
+    """Convex function must have positive semi-definite Hessian everywhere."""
+    model = ICNN(input_dim=3, hidden_dims=[16, 16])
+    model.eval()
+    rng = torch.Generator().manual_seed(42)
+    for _ in range(20):
+        x = torch.randn(1, 3, generator=rng, requires_grad=True)
+        y = model(x)
+
+        # Compute Hessian via autograd
+        grad = torch.autograd.grad(y, x, create_graph=True)[0]
+        H = torch.zeros(3, 3)
+        for i in range(3):
+            g2 = torch.autograd.grad(grad[0, i], x, retain_graph=True)[0]
+            H[i] = g2[0]
+
+        eigenvalues = torch.linalg.eigvalsh(H)
+        assert (eigenvalues >= -1e-5).all(), f"Hessian not PSD: eigenvalues={eigenvalues}"
+
+
+def test_hessian_psd_different_dims():
+    """PSD check for different input dimensions."""
+    for in_dim in [2, 5]:
+        model = ICNN(input_dim=in_dim, hidden_dims=[8, 8])
+        model.eval()
+        x = torch.randn(1, in_dim, requires_grad=True)
+        y = model(x)
+        grad = torch.autograd.grad(y, x, create_graph=True)[0]
+        H = torch.zeros(in_dim, in_dim)
+        for i in range(in_dim):
+            g2 = torch.autograd.grad(grad[0, i], x, retain_graph=True)[0]
+            H[i] = g2[0]
+        eigenvalues = torch.linalg.eigvalsh(H)
+        assert (eigenvalues >= -1e-5).all()
+
+
+# ── Multiple activations ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize("activation", ["softplus", "relu", "tanh"])
+def test_forward_with_activation(activation):
+    model = ICNN(input_dim=3, hidden_dims=[16, 16], activation=activation)
+    x = torch.randn(10, 3)
+    y = model(x)
+    assert y.shape == (10, 1)
+    assert torch.all(torch.isfinite(y))
+
+
+@pytest.mark.parametrize("activation", ["softplus", "relu"])
+def test_convexity_with_activation(activation):
+    """Convexity guaranteed for softplus and relu (convex, non-decreasing)."""
+    model = ICNN(input_dim=3, hidden_dims=[16, 16], activation=activation)
+    model.eval()
+    x1 = torch.randn(50, 3)
+    x2 = torch.randn(50, 3)
+    with torch.no_grad():
+        f_mix = model(0.5 * x1 + 0.5 * x2)
+        f_avg = 0.5 * model(x1) + 0.5 * model(x2)
+    assert (f_mix <= f_avg + 1e-5).all()
+
+
+# ── Architecture variants ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("hidden_dims", [[8], [32, 32], [16, 16, 16], [64, 32]])
+def test_architecture_variants(hidden_dims):
+    model = ICNN(input_dim=3, hidden_dims=hidden_dims)
+    x = torch.randn(5, 3)
+    y = model(x)
+    assert y.shape == (5, 1)
+    assert model.input_dim == 3
+    assert model.output_dim == 1
+
+
+def test_default_hidden_dims():
+    model = ICNN(input_dim=3)
+    assert model._hidden_dims == [64, 64]
+
+
+# ── Export save/load roundtrip ────────────────────────────────────
+
+
+def test_export_metadata():
+    model = ICNN(input_dim=3, hidden_dims=[16, 8])
+    in_norm = Normalizer().fit(np.random.randn(50, 3))
+    exported = extract_weights(model, in_norm)
+    assert exported.metadata["architecture"] == "icnn"
+    assert exported.metadata["input_dim"] == 3
+    assert exported.metadata["output_dim"] == 1
+    assert len(exported.layers) > 0
+    assert len(exported.weights) > 0
+
+
+def test_export_save_load(tmp_path):
+    model = ICNN(input_dim=3, hidden_dims=[16])
+    in_norm = Normalizer().fit(np.random.randn(50, 3))
+    energy_norm = Normalizer().fit(np.random.randn(50, 1))
+    exported = extract_weights(model, in_norm, energy_norm)
+    path = tmp_path / "icnn.npz"
+    exported.save(str(path))
+    loaded = ExportedModel.load(str(path))
+    assert loaded.metadata["architecture"] == "icnn"
+    assert loaded.metadata["input_dim"] == 3
+    for k in exported.weights:
+        np.testing.assert_array_equal(exported.weights[k], loaded.weights[k])
+    np.testing.assert_array_equal(loaded.input_normalizer["mean"], exported.input_normalizer["mean"])
+    np.testing.assert_array_equal(loaded.output_normalizer["mean"], exported.output_normalizer["mean"])
+
+
+# ── Layer sequence ────────────────────────────────────────────────
+
+
+def test_layer_sequence_structure():
+    model = ICNN(input_dim=3, hidden_dims=[16, 8])
+    seq = model.layer_sequence()
+    # 3 layers: wx_0, wz_0+wx_1, wz_final+wx_final
+    assert len(seq) == 3
+    assert seq[0].weights == "wx_layers.0.weight"
+    assert seq[0].bias == "wx_layers.0.bias"
+    assert seq[0].activation == "softplus"
+    assert seq[1].weights == "wz_layers.0.weight"
+    assert seq[1].bias == "wx_layers.1.bias"
+    assert seq[2].weights == "wz_final.weight"
+    assert seq[2].bias == "wx_final.bias"
+    assert seq[2].activation == "identity"
+
+
+def test_layer_sequence_single_hidden():
+    """Single hidden layer: wx_0 + output."""
+    model = ICNN(input_dim=3, hidden_dims=[16])
+    seq = model.layer_sequence()
+    assert len(seq) == 2
+    assert seq[0].activation == "softplus"
+    assert seq[1].activation == "identity"
+
+
+# ── Training integration ─────────────────────────────────────────
+
+
+def test_training_with_energy_stress_loss():
+    from hyper_surrogate.data.dataset import MaterialDataset
+    from hyper_surrogate.training.losses import EnergyStressLoss
+    from hyper_surrogate.training.trainer import Trainer
+
+    model = ICNN(input_dim=3, hidden_dims=[8, 8])
+    n = 100
+    X = np.random.randn(n, 3).astype(np.float32)
+    W = np.random.randn(n, 1).astype(np.float32)
+    S = np.random.randn(n, 3).astype(np.float32)
+
+    train_ds = MaterialDataset(X[:80], (W[:80], S[:80]))
+    val_ds = MaterialDataset(X[80:], (W[80:], S[80:]))
+
+    result = Trainer(
+        model,
+        train_ds,
+        val_ds,
+        loss_fn=EnergyStressLoss(alpha=1.0, beta=1.0),
+        max_epochs=5,
+        lr=1e-3,
+    ).fit()
+    assert len(result.history["train_loss"]) == 5
+    assert result.model is not None
+
+
+def test_training_loss_decreases():
+    from hyper_surrogate.data.dataset import MaterialDataset
+    from hyper_surrogate.training.losses import EnergyStressLoss
+    from hyper_surrogate.training.trainer import Trainer
+
+    model = ICNN(input_dim=3, hidden_dims=[16, 16])
+    n = 200
+    # Use simple learnable target: W = sum(x^2)
+    X = np.random.randn(n, 3).astype(np.float32) * 0.5
+    W = (X**2).sum(axis=1, keepdims=True).astype(np.float32)
+    S = (2 * X).astype(np.float32)
+
+    train_ds = MaterialDataset(X[:160], (W[:160], S[:160]))
+    val_ds = MaterialDataset(X[160:], (W[160:], S[160:]))
+
+    result = Trainer(
+        model,
+        train_ds,
+        val_ds,
+        loss_fn=EnergyStressLoss(alpha=1.0, beta=1.0),
+        max_epochs=50,
+        lr=1e-3,
+        batch_size=64,
+    ).fit()
+    # Loss should decrease
+    assert result.history["train_loss"][-1] < result.history["train_loss"][0]
+
+
+# ── Consistency with PolyconvexICNN ───────────────────────────────
+
+
+def test_single_branch_polyconvex_matches_icnn():
+    """Single-group PolyconvexICNN should behave like ICNN."""
+    from hyper_surrogate.models.polyconvex import PolyconvexICNN
+
+    torch.manual_seed(42)
+    icnn = ICNN(input_dim=3, hidden_dims=[8, 8], activation="softplus")
+
+    torch.manual_seed(42)
+    poly = PolyconvexICNN(groups=[[0, 1, 2]], hidden_dims=[8, 8], activation="softplus")
+
+    # Same architecture, same seed -> same weights
+    x = torch.randn(5, 3)
+    y_icnn = icnn(x)
+    y_poly = poly(x)
+    # Shapes match
+    assert y_icnn.shape == y_poly.shape == (5, 1)

--- a/tests/test_mooney_rivlin.py
+++ b/tests/test_mooney_rivlin.py
@@ -1,0 +1,339 @@
+"""Comprehensive tests for MooneyRivlin material model.
+
+Mirrors NeoHooke test coverage: symbolic SEF, energy evaluation,
+PK2 stress, CMAT tangent, energy gradients, and finite-difference validation.
+"""
+
+import numpy as np
+import pytest
+import sympy as sym
+
+from hyper_surrogate.mechanics.kinematics import Kinematics as K
+from hyper_surrogate.mechanics.materials import MooneyRivlin
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mat():
+    return MooneyRivlin()
+
+
+@pytest.fixture
+def f0():
+    return np.eye(3)
+
+
+@pytest.fixture
+def f_uni():
+    # Uniaxial stretch 3 along x (incompressible)
+    return np.diag([3.0, 1.0 / np.sqrt(3.0), 1.0 / np.sqrt(3.0)])
+
+
+@pytest.fixture
+def f_arbitrary():
+    return np.array([[3.0, 0.4, 0.1], [0.4, 1.0 / np.sqrt(3.0), 0.1], [0.9, -0.2, 0.6]])
+
+
+@pytest.fixture
+def f_arbitrary2():
+    return np.array([[3.0, 0.4, 0.1], [0.4, 0.45, 0.1], [0.9, -0.2, 0.9]])
+
+
+@pytest.fixture
+def f_batch(f0, f_uni, f_arbitrary, f_arbitrary2):
+    return np.array([f0, f_uni, f_arbitrary, f_arbitrary2])
+
+
+@pytest.fixture
+def c_batch(f_batch):
+    return K.right_cauchy_green(f_batch)
+
+
+# ── Properties ────────────────────────────────────────────────────
+
+
+def test_default_params():
+    mr = MooneyRivlin()
+    assert mr._params["C10"] == 0.3
+    assert mr._params["C01"] == 0.2
+    assert mr._params["KBULK"] == 1000.0
+
+
+def test_custom_params():
+    mr = MooneyRivlin({"C10": 1.0, "C01": 0.5, "KBULK": 500.0})
+    assert mr._params["C10"] == 1.0
+    assert mr._params["C01"] == 0.5
+    assert mr._params["KBULK"] == 500.0
+
+
+def test_not_anisotropic():
+    assert not MooneyRivlin().is_anisotropic
+    assert MooneyRivlin().fiber_direction is None
+
+
+# ── SEF symbolic ──────────────────────────────────────────────────
+
+
+def test_sef_expression():
+    mr = MooneyRivlin()
+    h = mr.handler
+    C10, C01, KBULK = sym.Symbol("C10"), sym.Symbol("C01"), sym.Symbol("KBULK")
+    I1 = h.isochoric_invariant1
+    I2 = h.isochoric_invariant2
+    I3 = h.invariant3
+    expected = (I1 - 3) * C10 + (I2 - 3) * C01 + 0.25 * KBULK * (I3 - 1 - 2 * sym.log(I3**0.5))
+    assert sym.simplify(mr.sef - expected) == 0
+
+
+def test_pk2_expr_shape():
+    mr = MooneyRivlin()
+    assert mr.pk2_expr.shape == (3, 3)
+    assert isinstance(mr.pk2_expr, sym.Matrix)
+
+
+def test_cmat_expr_shape():
+    mr = MooneyRivlin()
+    assert mr.cmat_expr.shape == (3, 3, 3, 3)
+
+
+# ── Energy evaluation ─────────────────────────────────────────────
+
+
+def test_energy_at_identity(c_batch):
+    mr = MooneyRivlin({"C10": 1.0, "C01": 0.5, "KBULK": 1.0})
+    energy = mr.evaluate_energy(c_batch)
+    assert energy.shape == (4,)
+    assert energy[0] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_energy_positive_under_deformation(c_batch):
+    mr = MooneyRivlin({"C10": 1.0, "C01": 0.5, "KBULK": 1.0})
+    energy = mr.evaluate_energy(c_batch)
+    assert np.all(energy[1:] > 0)
+
+
+def test_energy_reduces_to_neohooke_when_c01_zero(c_batch):
+    """With C01=0, MooneyRivlin should match NeoHooke."""
+    from hyper_surrogate.mechanics.materials import NeoHooke
+
+    mr = MooneyRivlin({"C10": 0.5, "C01": 0.0, "KBULK": 1000.0})
+    nh = NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+    np.testing.assert_allclose(mr.evaluate_energy(c_batch), nh.evaluate_energy(c_batch), rtol=1e-10)
+
+
+def test_energy_i2_contribution():
+    """C01 term should increase energy beyond NeoHooke."""
+    from hyper_surrogate.mechanics.materials import NeoHooke
+
+    F = np.diag([1.1, 1.0 / np.sqrt(1.1), 1.0 / np.sqrt(1.1)]).reshape(1, 3, 3)
+    C = K.right_cauchy_green(F)
+    mr = MooneyRivlin({"C10": 0.5, "C01": 0.2, "KBULK": 1000.0})
+    nh = NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+    # MooneyRivlin has extra I2 term, so energy should differ
+    assert mr.evaluate_energy(C)[0] > nh.evaluate_energy(C)[0]
+
+
+# ── PK2 stress ────────────────────────────────────────────────────
+
+
+def test_pk2_at_identity():
+    """MooneyRivlin PK2 at identity should be zero (stress-free reference)."""
+    mr = MooneyRivlin()
+    C = np.eye(3).reshape(1, 3, 3)
+    pk2 = mr.evaluate_pk2(C)
+    assert pk2.shape == (1, 3, 3)
+    np.testing.assert_allclose(pk2[0], np.zeros((3, 3)), atol=1e-10)
+
+
+def test_pk2_symmetry(c_batch):
+    """PK2 should be symmetric."""
+    mr = MooneyRivlin()
+    pk2 = mr.evaluate_pk2(c_batch)
+    for i in range(len(c_batch)):
+        np.testing.assert_allclose(pk2[i], pk2[i].T, atol=1e-10)
+
+
+def test_pk2_shape(c_batch):
+    mr = MooneyRivlin()
+    pk2 = mr.evaluate_pk2(c_batch)
+    assert pk2.shape == (4, 3, 3)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"C10": 1.0, "C01": 0.0, "KBULK": 0.0},  # isochoric I1 only
+        {"C10": 0.0, "C01": 1.0, "KBULK": 0.0},  # isochoric I2 only
+        {"C10": 0.0, "C01": 0.0, "KBULK": 1000.0},  # volumetric only
+        {"C10": 0.3, "C01": 0.2, "KBULK": 1000.0},  # full
+    ],
+)
+def test_pk2_superposition(params, c_batch):
+    """PK2 with combined params == sum of individual PK2 contributions."""
+    mr = MooneyRivlin(params)
+    pk2_combined = mr.evaluate_pk2(c_batch)
+
+    pk2_sum = np.zeros_like(pk2_combined)
+    for key, val in params.items():
+        if val != 0.0:
+            single_params = {k: 0.0 for k in params}
+            single_params[key] = val
+            pk2_sum += MooneyRivlin(single_params).evaluate_pk2(c_batch)
+
+    np.testing.assert_allclose(pk2_combined, pk2_sum, atol=1e-10)
+
+
+def test_pk2_reduces_to_neohooke_when_c01_zero(c_batch):
+    from hyper_surrogate.mechanics.materials import NeoHooke
+
+    mr = MooneyRivlin({"C10": 0.5, "C01": 0.0, "KBULK": 1000.0})
+    nh = NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+    np.testing.assert_allclose(mr.evaluate_pk2(c_batch), nh.evaluate_pk2(c_batch), atol=1e-10)
+
+
+# ── CMAT tangent ──────────────────────────────────────────────────
+
+
+def test_cmat_shape(c_batch):
+    mr = MooneyRivlin()
+    cmat = mr.evaluate_cmat(c_batch)
+    assert cmat.shape == (4, 3, 3, 3, 3)
+
+
+def test_cmat_at_identity():
+    mr = MooneyRivlin({"C10": 1.0, "C01": 0.0, "KBULK": 0.0})
+    C = np.eye(3).reshape(1, 3, 3)
+    cmat = mr.evaluate_cmat(C)
+    assert cmat.shape == (1, 3, 3, 3, 3)
+    assert np.all(np.isfinite(cmat))
+
+
+def test_cmat_major_symmetry(c_batch):
+    """CMAT should have major symmetry: C_ijkl = C_klij."""
+    mr = MooneyRivlin()
+    cmat = mr.evaluate_cmat(c_batch)
+    for n in range(len(c_batch)):
+        for i in range(3):
+            for j in range(3):
+                for k in range(3):
+                    for l in range(3):  # noqa: E741
+                        assert cmat[n, i, j, k, l] == pytest.approx(cmat[n, k, l, i, j], abs=1e-10)
+
+
+def test_cmat_superposition(c_batch):
+    """CMAT with combined params == sum of individual CMAT contributions."""
+    params = {"C10": 0.3, "C01": 0.2, "KBULK": 1000.0}
+    mr = MooneyRivlin(params)
+    cmat_combined = mr.evaluate_cmat(c_batch)
+
+    cmat_sum = np.zeros_like(cmat_combined)
+    for key, val in params.items():
+        if val != 0.0:
+            single_params = {k: 0.0 for k in params}
+            single_params[key] = val
+            cmat_sum += MooneyRivlin(single_params).evaluate_cmat(c_batch)
+
+    np.testing.assert_allclose(cmat_combined, cmat_sum, atol=1e-10)
+
+
+# ── Energy gradients ──────────────────────────────────────────────
+
+
+def test_grad_shape():
+    mr = MooneyRivlin()
+    C = np.eye(3).reshape(1, 3, 3) * 1.01
+    C = (C + np.transpose(C, (0, 2, 1))) / 2
+    grad = mr.evaluate_energy_grad_invariants(C)
+    assert grad.shape == (1, 3)
+
+
+def test_grad_at_identity():
+    """At identity: dW/dI1_bar = C10, dW/dI2_bar = C01, dW/dJ = 0."""
+    mr = MooneyRivlin({"C10": 0.3, "C01": 0.2, "KBULK": 1000.0})
+    C = np.eye(3).reshape(1, 3, 3)
+    grad = mr.evaluate_energy_grad_invariants(C)
+    np.testing.assert_allclose(grad[0, 0], 0.3, rtol=1e-10)  # dW/dI1_bar = C10
+    np.testing.assert_allclose(grad[0, 1], 0.2, rtol=1e-10)  # dW/dI2_bar = C01
+    np.testing.assert_allclose(grad[0, 2], 0.0, atol=1e-14)  # dW/dJ = 0 at J=1
+
+
+def test_grad_finite_difference():
+    """Verify gradients against finite differences of sef_from_invariants."""
+    from sympy import Symbol, lambdify
+
+    mr = MooneyRivlin()
+    F = np.diag([1.15, 0.95, 1.0 / (1.15 * 0.95)]).reshape(1, 3, 3)
+    C = K.right_cauchy_green(F)
+
+    i1 = float(K.isochoric_invariant1(C)[0])
+    i2 = float(K.isochoric_invariant2(C)[0])
+    j = float(np.sqrt(K.det_invariant(C)[0]))
+
+    # Symbolic energy function
+    I1s, I2s, Js = Symbol("I1b"), Symbol("I2b"), Symbol("J")
+    W_expr = mr.sef_from_invariants(I1s, I2s, Js)
+    param_syms = list(mr._symbols.values())
+    fn = lambdify((I1s, I2s, Js, *param_syms), W_expr, modules="numpy")
+    param_vals = list(mr._params.values())
+
+    grad_analytical = mr.evaluate_energy_grad_invariants(C)[0]
+
+    eps = 1e-7
+    inv_vals = [i1, i2, j]
+    grad_fd = np.zeros(3)
+    for k in range(3):
+        inv_p = list(inv_vals)
+        inv_m = list(inv_vals)
+        inv_p[k] += eps
+        inv_m[k] -= eps
+        W_p = float(fn(*inv_p, *param_vals))
+        W_m = float(fn(*inv_m, *param_vals))
+        grad_fd[k] = (W_p - W_m) / (2 * eps)
+
+    np.testing.assert_allclose(grad_analytical, grad_fd, rtol=1e-5, atol=1e-10)
+
+
+# ── PK2 finite-difference validation ─────────────────────────────
+
+
+def test_pk2_consistent_with_energy():
+    """PK2 = 2 * dW/dC: verify numerically via finite differences on energy."""
+    mr = MooneyRivlin({"C10": 0.5, "C01": 0.3, "KBULK": 100.0})
+    F = np.diag([1.1, 0.95, 1.0 / (1.1 * 0.95)])
+    C = F.T @ F
+
+    eps = 1e-7
+    pk2_fd = np.zeros((3, 3))
+    for i in range(3):
+        for j in range(i, 3):
+            C_p = C.copy()
+            C_m = C.copy()
+            # Symmetric perturbation: perturb E_ij = (C_ij + C_ji)/2
+            C_p[i, j] += eps
+            C_p[j, i] += eps
+            C_m[i, j] -= eps
+            C_m[j, i] -= eps
+            W_p = mr.evaluate_energy(C_p.reshape(1, 3, 3))[0]
+            W_m = mr.evaluate_energy(C_m.reshape(1, 3, 3))[0]
+            # S_ij = dW/dE_ij = (W_p - W_m) / (2*eps) for the symmetric part
+            val = (W_p - W_m) / (2 * eps)
+            pk2_fd[i, j] = val
+            pk2_fd[j, i] = val
+
+    pk2_analytical = mr.evaluate_pk2(C.reshape(1, 3, 3))[0]
+    np.testing.assert_allclose(pk2_analytical, pk2_fd, rtol=1e-4)
+
+
+# ── Batch consistency ─────────────────────────────────────────────
+
+
+def test_batch_consistency():
+    """Batch of identical deformations gives identical results."""
+    mr = MooneyRivlin()
+    F_single = np.diag([1.1, 0.95, 1.0 / (1.1 * 0.95)])
+    F_batch = np.tile(F_single, (5, 1, 1))
+    C = K.right_cauchy_green(F_batch)
+    pk2 = mr.evaluate_pk2(C)
+    for i in range(1, 5):
+        np.testing.assert_allclose(pk2[i], pk2[0], rtol=1e-12)


### PR DESCRIPTION
## Summary
- **Fix bug** in `SymbolicHandler.isochoric_invariant2`: used `I1_bar²` (already J-scaled) instead of `tr(C)²`, double-counting `J^{-2/3}`. This caused incorrect PK2/CMAT for any material using I2 (MooneyRivlin). MooneyRivlin PK2 at identity was non-zero — now correctly returns zero.
- **Add 58 new tests** across three files covering MooneyRivlin, ICNN, and end-to-end integration

## New test files

| File | Tests | Coverage |
|---|---|---|
| `test_mooney_rivlin.py` | 27 | SEF, energy, PK2 (identity=0, superposition, symmetry, FD validation), CMAT, gradients |
| `test_models_icnn_deep.py` | 24 | Hessian PSD, convexity (5 t-values, 3 activations), export save/load, training, PolyconvexICNN consistency |
| `test_integration_e2e.py` | 7 | Train MLP/ICNN → export → numpy forward pass matches PyTorch, Fortran generation, file roundtrip |

## Test plan
- [x] `make check` passes (ruff, mypy, deptry)
- [x] `make test` passes (237 tests, 0 failures)
- [x] MooneyRivlin PK2 at identity = 0 (was non-zero before fix)
- [x] NeoHooke tests unaffected (doesn't use I2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)