### PR TITLE
docs: add constitutive theory reference and tutorial suite

### DIFF
--- a/docs/constitutive_theory.md
+++ b/docs/constitutive_theory.md
@@ -1,0 +1,476 @@
+# Constitutive Theory of Hyperelasticity
+
+This document provides a self-contained reference on the continuum mechanics theory underpinning **hyper-surrogate**. It covers kinematics, strain energy functions, stress measures, material tangents, and the specific constitutive models implemented in the library.
+
+---
+
+## 1. Kinematics of Finite Deformation
+
+### 1.1 Deformation Gradient
+
+The deformation gradient $\mathbf{F}$ maps an infinitesimal material line element $d\mathbf{X}$ in the reference configuration to its image $d\mathbf{x}$ in the current configuration:
+
+$$d\mathbf{x} = \mathbf{F}\, d\mathbf{X}, \qquad F_{iJ} = \frac{\partial x_i}{\partial X_J}$$
+
+The Jacobian determinant $J = \det(\mathbf{F}) > 0$ measures volume change. For incompressible materials, $J = 1$.
+
+### 1.2 Strain Tensors
+
+| Tensor | Symbol | Definition | Configuration |
+|--------|--------|------------|---------------|
+| Right Cauchy-Green | $\mathbf{C}$ | $\mathbf{F}^T \mathbf{F}$ | Reference (Lagrangian) |
+| Left Cauchy-Green | $\mathbf{b}$ | $\mathbf{F}\, \mathbf{F}^T$ | Current (Eulerian) |
+| Green-Lagrange strain | $\mathbf{E}$ | $\frac{1}{2}(\mathbf{C} - \mathbf{I})$ | Reference |
+
+In `hyper-surrogate`, all constitutive evaluations are based on $\mathbf{C}$:
+
+```python
+import hyper_surrogate as hs
+
+C = hs.Kinematics.right_cauchy_green(F)  # (N, 3, 3)
+B = hs.Kinematics.left_cauchy_green(F)   # (N, 3, 3)
+```
+
+### 1.3 Principal Invariants of $\mathbf{C}$
+
+The three principal invariants encode the deformation state in a rotation-invariant manner:
+
+$$I_1 = \text{tr}(\mathbf{C}) = \lambda_1^2 + \lambda_2^2 + \lambda_3^2$$
+
+$$I_2 = \frac{1}{2}\left[(\text{tr}\,\mathbf{C})^2 - \text{tr}(\mathbf{C}^2)\right] = \lambda_1^2\lambda_2^2 + \lambda_2^2\lambda_3^2 + \lambda_3^2\lambda_1^2$$
+
+$$I_3 = \det(\mathbf{C}) = J^2 = \lambda_1^2 \lambda_2^2 \lambda_3^2$$
+
+where $\lambda_1, \lambda_2, \lambda_3$ are the principal stretches.
+
+### 1.4 Isochoric-Volumetric Split
+
+To decouple shape change from volume change, the deformation gradient is multiplicatively decomposed:
+
+$$\mathbf{F} = J^{1/3}\, \bar{\mathbf{F}}, \qquad \bar{\mathbf{C}} = J^{-2/3}\, \mathbf{C}$$
+
+The **isochoric (modified) invariants** are:
+
+| Invariant | Expression | Physical Meaning |
+|-----------|------------|-----------------|
+| $\bar{I}_1$ | $J^{-2/3}\, I_1$ | Isochoric shape change (trace) |
+| $\bar{I}_2$ | $J^{-4/3}\, I_2$ | Isochoric shape change (cofactor) |
+| $J$ | $\sqrt{I_3}$ | Volume ratio |
+
+```python
+I1_bar = hs.Kinematics.isochoric_invariant1(C)  # (N,)
+I2_bar = hs.Kinematics.isochoric_invariant2(C)  # (N,)
+J      = hs.Kinematics.jacobian(F)              # (N,)
+```
+
+### 1.5 Fiber (Pseudo-)Invariants
+
+For anisotropic materials with a preferred fiber direction $\mathbf{a}_0$ (unit vector in the reference configuration):
+
+$$I_4 = \mathbf{a}_0 \cdot \mathbf{C}\, \mathbf{a}_0 = \lambda_f^2$$
+
+$$I_5 = \mathbf{a}_0 \cdot \mathbf{C}^2\, \mathbf{a}_0$$
+
+where $\lambda_f$ is the fiber stretch. $I_4$ measures stretch along the fiber; $I_5$ captures coupling between fiber stretch and shear.
+
+```python
+fiber_dir = np.array([1.0, 0.0, 0.0])
+I4 = hs.Kinematics.fiber_invariant4(C, fiber_dir)  # (N,)
+I5 = hs.Kinematics.fiber_invariant5(C, fiber_dir)  # (N,)
+```
+
+### 1.6 Principal Stretches
+
+The principal stretches $\lambda_i$ are the square roots of the eigenvalues of $\mathbf{C}$:
+
+$$\mathbf{C}\, \mathbf{N}_i = \lambda_i^2\, \mathbf{N}_i, \qquad i = 1, 2, 3$$
+
+```python
+stretches = hs.Kinematics.principal_stretches(C)  # (N, 3), sorted descending
+```
+
+---
+
+## 2. Stress Measures
+
+### 2.1 Second Piola-Kirchhoff Stress
+
+For a hyperelastic material defined by a strain energy function $W(\mathbf{C})$, the second Piola-Kirchhoff (PK2) stress is:
+
+$$\mathbf{S} = 2\frac{\partial W}{\partial \mathbf{C}}$$
+
+This is a **symmetric** tensor in the reference configuration.
+
+### 2.2 Cauchy Stress (Push-Forward)
+
+The Cauchy (true) stress in the current configuration is obtained by the push-forward operation:
+
+$$\boldsymbol{\sigma} = \frac{1}{J}\, \mathbf{F}\, \mathbf{S}\, \mathbf{F}^T$$
+
+### 2.3 Material and Spatial Tangents
+
+The **material tangent** (elasticity tensor in the reference configuration):
+
+$$\mathbb{C} = 2\frac{\partial \mathbf{S}}{\partial \mathbf{C}} = 4\frac{\partial^2 W}{\partial \mathbf{C}\, \partial \mathbf{C}}$$
+
+The **spatial tangent** is obtained via push-forward to the current configuration and includes the **Jaumann rate correction** required by most FE solvers (e.g. Abaqus):
+
+$$c_{ijkl} = \frac{1}{J} F_{iI} F_{jJ} F_{kK} F_{lL}\, \mathbb{C}_{IJKL} + \text{Jaumann correction}$$
+
+### 2.4 Voigt Notation
+
+For FE implementation, symmetric tensors and tangent matrices are stored in Voigt notation:
+
+| Voigt Index | Tensor Components |
+|:-----------:|:-----------------:|
+| 1 | 11 (xx) |
+| 2 | 22 (yy) |
+| 3 | 33 (zz) |
+| 4 | 12 (xy) |
+| 5 | 13 (xz) |
+| 6 | 23 (yz) |
+
+- **Stress**: $\mathbf{S} \to [S_{11}, S_{22}, S_{33}, S_{12}, S_{13}, S_{23}]$ (6 components)
+- **Tangent**: $\mathbb{C} \to 6 \times 6$ matrix
+
+---
+
+## 3. Strain Energy Functions
+
+### 3.1 General Structure
+
+All isotropic models in `hyper-surrogate` follow the decoupled form:
+
+$$W(\mathbf{C}) = W_{\text{iso}}(\bar{I}_1, \bar{I}_2) + U(J)$$
+
+where $W_{\text{iso}}$ is the isochoric (shape-changing) part and $U(J)$ is the volumetric penalty. Anisotropic models add fiber contributions:
+
+$$W(\mathbf{C}) = W_{\text{iso}}(\bar{I}_1, \bar{I}_2) + W_{\text{fiber}}(I_4, I_5) + U(J)$$
+
+### 3.2 Volumetric Penalty
+
+All models share the same volumetric term:
+
+$$U(J) = \frac{K}{4}\left(J^2 - 1 - 2\ln J\right)$$
+
+| Property | Value |
+|----------|-------|
+| $U(1) = 0$ | Zero energy at $J=1$ |
+| $U'(1) = 0$ | Zero pressure at $J=1$ |
+| $U''(1) = K$ | Bulk modulus at $J=1$ |
+| $U(J) \to \infty$ as $J \to 0^+$ or $J \to \infty$ | Penalty barrier |
+
+The parameter $K$ (bulk modulus, `KBULK` in code) controls the degree of near-incompressibility. Typical values: $K = 100$--$10000 \times$ shear modulus.
+
+---
+
+## 4. Isotropic Material Models
+
+### 4.1 Neo-Hooke
+
+The simplest invariant-based hyperelastic model:
+
+$$W = C_{10}(\bar{I}_1 - 3) + U(J)$$
+
+| Parameter | Symbol | Meaning | Typical Range |
+|-----------|--------|---------|---------------|
+| `C10` | $C_{10}$ | Half the initial shear modulus ($\mu/2$) | 0.1 -- 10 MPa |
+| `KBULK` | $K$ | Bulk modulus | 100 -- 10000 MPa |
+
+**Stress derivatives**:
+
+$$\frac{\partial W}{\partial \bar{I}_1} = C_{10}, \qquad \frac{\partial W}{\partial \bar{I}_2} = 0$$
+
+**Use case**: Simple rubber-like materials at moderate strains ($< 100\%$).
+
+```python
+from hyper_surrogate import NeoHooke
+mat = NeoHooke(parameters={"C10": 0.5, "KBULK": 1000.0})
+```
+
+### 4.2 Mooney-Rivlin
+
+Extends Neo-Hooke with dependence on the second invariant:
+
+$$W = C_{10}(\bar{I}_1 - 3) + C_{01}(\bar{I}_2 - 3) + U(J)$$
+
+| Parameter | Symbol | Meaning |
+|-----------|--------|---------|
+| `C10` | $C_{10}$ | First invariant coefficient |
+| `C01` | $C_{01}$ | Second invariant coefficient |
+| `KBULK` | $K$ | Bulk modulus |
+
+The initial shear modulus is $\mu = 2(C_{10} + C_{01})$.
+
+**Use case**: Rubber with improved accuracy at moderate-to-large strains.
+
+```python
+from hyper_surrogate import MooneyRivlin
+mat = MooneyRivlin(parameters={"C10": 0.3, "C01": 0.2, "KBULK": 1000.0})
+```
+
+### 4.3 Yeoh (Reduced Polynomial)
+
+Third-order polynomial in $(\bar{I}_1 - 3)$:
+
+$$W = C_{10}(\bar{I}_1 - 3) + C_{20}(\bar{I}_1 - 3)^2 + C_{30}(\bar{I}_1 - 3)^3 + U(J)$$
+
+| Parameter | Symbol | Role |
+|-----------|--------|------|
+| `C10` | $C_{10}$ | Linear (small-strain) response |
+| `C20` | $C_{20}$ | Softening at moderate strains (often $< 0$) |
+| `C30` | $C_{30}$ | Stiffening at large strains (often $> 0$) |
+
+**Use case**: Rubber undergoing large deformations with strain-stiffening. The S-shaped stress-strain curve of filled rubbers is well captured.
+
+```python
+from hyper_surrogate.mechanics.materials import Yeoh
+mat = Yeoh(parameters={"C10": 0.5, "C20": -0.01, "C30": 0.001, "KBULK": 1000.0})
+```
+
+### 4.4 Demiray (Exponential)
+
+Exponential model for soft biological tissues:
+
+$$W = \frac{C_1}{C_2}\left[\exp\!\left(C_2(\bar{I}_1 - 3)\right) - 1\right] + U(J)$$
+
+| Parameter | Symbol | Role |
+|-----------|--------|------|
+| `C1` | $C_1$ | Ground-state stiffness |
+| `C2` | $C_2$ | Exponential stiffening rate |
+
+At small strains ($\bar{I}_1 \approx 3$), the Taylor expansion gives $W \approx C_1(\bar{I}_1 - 3)$, recovering a Neo-Hooke response.
+
+**Use case**: Isotropic soft tissues (skin, blood vessel ground substance).
+
+```python
+from hyper_surrogate.mechanics.materials import Demiray
+mat = Demiray(parameters={"C1": 0.05, "C2": 8.0, "KBULK": 1000.0})
+```
+
+### 4.5 Ogden
+
+Principal-stretch-based formulation:
+
+$$W = \sum_{p=1}^{N} \frac{\mu_p}{\alpha_p}\left(\bar{\lambda}_1^{\alpha_p} + \bar{\lambda}_2^{\alpha_p} + \bar{\lambda}_3^{\alpha_p} - 3\right) + U(J)$$
+
+where $\bar{\lambda}_i = J^{-1/3} \lambda_i$ are the isochoric principal stretches.
+
+| Parameters | Constraint |
+|-----------|-----------|
+| $\mu_p, \alpha_p$ pairs | $\sum_p \mu_p \alpha_p = 2\mu$ (consistency with shear modulus) |
+
+Special cases:
+
+- $N=1,\ \alpha_1=2$: Neo-Hooke ($C_{10} = \mu_1/2$)
+- $N=2,\ \alpha_1=2,\ \alpha_2=-2$: Mooney-Rivlin
+
+**Note**: The Ogden model uses numerical eigenvalue decomposition (no closed-form symbolic SEF in terms of $I_1, I_2$).
+
+```python
+from hyper_surrogate.mechanics.materials import Ogden
+mat = Ogden(parameters={
+    "mu1": 1.491, "alpha1": 1.3,
+    "mu2": 0.003, "alpha2": 5.0,
+    "mu3": -0.024, "alpha3": -2.0,
+    "KBULK": 1000.0,
+})
+```
+
+### 4.6 Fung (Exponential, Green Strain)
+
+Exponential model formulated in terms of Green-Lagrange strain components:
+
+$$W = \frac{c}{2}\left[\exp(Q) - 1\right] + U(J)$$
+
+$$Q = b_1 E_{11}^2 + b_2(E_{22}^2 + E_{33}^2 + 2E_{12}^2)$$
+
+| Parameter | Symbol | Role |
+|-----------|--------|------|
+| `c` | $c$ | Overall stiffness scaling |
+| `b1` | $b_1$ | Axial (fiber direction) stiffening |
+| `b2` | $b_2$ | Transverse stiffening |
+
+**Use case**: Arterial tissue, especially when the exponential stiffening is important in multiple directions.
+
+```python
+from hyper_surrogate.mechanics.materials import Fung
+mat = Fung(parameters={"c": 1.0, "b1": 10.0, "b2": 5.0, "KBULK": 1000.0})
+```
+
+---
+
+## 5. Anisotropic Material Models
+
+### 5.1 Holzapfel-Ogden (Single Fiber Family)
+
+Models arterial tissue with one family of collagen fibers embedded in a soft ground matrix:
+
+$$W = \underbrace{\frac{a}{2b}\left[\exp\!\left(b(\bar{I}_1 - 3)\right) - 1\right]}_{\text{ground substance}} + \underbrace{\frac{a_f}{2b_f}\left[\exp\!\left(b_f\langle I_4 - 1\rangle^2\right) - 1\right]}_{\text{fiber contribution}} + U(J)$$
+
+The **Macaulay bracket** $\langle \cdot \rangle = \max(0, \cdot)$ ensures fibers only contribute under **tension** ($I_4 > 1$, i.e. the fiber is stretched).
+
+| Parameter | Symbol | Meaning |
+|-----------|--------|---------|
+| `a` | $a$ | Ground substance stiffness (kPa) |
+| `b` | $b$ | Ground substance exponential coefficient |
+| `af` | $a_f$ | Fiber stiffness (kPa) |
+| `bf` | $b_f$ | Fiber exponential coefficient |
+| `KBULK` | $K$ | Bulk modulus |
+
+```python
+from hyper_surrogate import HolzapfelOgden
+mat = HolzapfelOgden(
+    parameters={"a": 0.059, "b": 8.023, "af": 18.472, "bf": 16.026, "KBULK": 1000.0},
+    fiber_direction=np.array([1.0, 0.0, 0.0]),
+)
+```
+
+### 5.2 Gasser-Ogden-Holzapfel (GOH) -- Dispersed Fibers
+
+Extends Holzapfel-Ogden with a **fiber dispersion** parameter $\kappa$:
+
+$$W = \frac{a}{2b}\left[\exp\!\left(b(\bar{I}_1 - 3)\right) - 1\right] + \frac{a_f}{2b_f}\left[\exp\!\left(b_f \bar{E}^2\right) - 1\right] + U(J)$$
+
+where the **generalized strain invariant** accounts for dispersion:
+
+$$\bar{E} = \kappa(\bar{I}_1 - 3) + (1 - 3\kappa)(I_4 - 1)$$
+
+| $\kappa$ Value | Physical Meaning |
+|:-------------:|------------------|
+| $0$ | Perfectly aligned fibers (reduces to Holzapfel-Ogden) |
+| $1/3$ | Isotropically dispersed (no preferred direction) |
+| $0 < \kappa < 1/3$ | Partially dispersed (realistic arterial tissue) |
+
+| Parameter | Symbol | Meaning |
+|-----------|--------|---------|
+| `kappa` | $\kappa$ | Fiber dispersion ($0 \le \kappa \le 1/3$) |
+
+Typical values for human arteries: $\kappa \approx 0.1$--$0.3$.
+
+```python
+from hyper_surrogate.mechanics.materials import GasserOgdenHolzapfel
+mat = GasserOgdenHolzapfel(
+    parameters={"a": 0.059, "b": 8.023, "af": 18.472, "bf": 16.026,
+                "kappa": 0.226, "KBULK": 1000.0},
+    fiber_direction=np.array([1.0, 0.0, 0.0]),
+)
+```
+
+### 5.3 Guccione (Cardiac Tissue)
+
+Transversely isotropic model for myocardial tissue, expressed in a **fiber-sheet-normal** local frame:
+
+$$W = \frac{C}{2}\left[\exp(Q) - 1\right] + U(J)$$
+
+$$Q = b_f E_{ff}^2 + b_t(E_{ss}^2 + E_{nn}^2 + 2E_{sn}^2) + b_{fs}(2E_{fs}^2 + 2E_{fn}^2)$$
+
+where $E_{ff}, E_{ss}, E_{nn}, E_{fs}, E_{fn}, E_{sn}$ are the Green-Lagrange strain components in the local fiber ($f$), sheet ($s$), and normal ($n$) frame.
+
+| Parameter | Symbol | Role |
+|-----------|--------|------|
+| `C` | $C$ | Overall stiffness |
+| `bf` | $b_f$ | Fiber direction stiffening |
+| `bt` | $b_t$ | Transverse (sheet/normal) stiffening |
+| `bfs` | $b_{fs}$ | Fiber-sheet shear stiffening |
+
+This model requires **two** direction vectors: `fiber_direction` and `sheet_direction`. The normal direction is computed as $\mathbf{n}_0 = \mathbf{f}_0 \times \mathbf{s}_0$.
+
+```python
+from hyper_surrogate.mechanics.materials import Guccione
+mat = Guccione(
+    parameters={"C": 0.876, "bf": 18.48, "bt": 3.58, "bfs": 1.627, "KBULK": 1000.0},
+    fiber_direction=np.array([1.0, 0.0, 0.0]),
+    sheet_direction=np.array([0.0, 1.0, 0.0]),
+)
+```
+
+---
+
+## 6. Summary: Model Selection Guide
+
+| Tissue / Application | Recommended Model | Why |
+|----------------------|-------------------|-----|
+| Simple rubber (small strain) | Neo-Hooke | 1 parameter, sufficient for $< 50\%$ strain |
+| Rubber (moderate strain) | Mooney-Rivlin | 2 parameters, captures $I_2$-dependence |
+| Rubber (large strain, stiffening) | Yeoh or Ogden | Captures S-shaped stress-strain |
+| Isotropic soft tissue | Demiray | Exponential stiffening, 2 parameters |
+| Arterial wall (single fiber family) | Holzapfel-Ogden | Fiber tension-only via Macaulay bracket |
+| Arterial wall (dispersed fibers) | GOH | Adds realistic fiber dispersion |
+| Cardiac tissue | Guccione | Fiber-sheet-normal anisotropy |
+| General isotropic (data-driven fit) | Ogden ($N$-term) | Very flexible, stretch-based |
+
+---
+
+## 7. Chain Rule for Invariant-Based SEFs
+
+When the SEF is written in terms of invariants $W(\bar{I}_1, \bar{I}_2, J, I_4, I_5)$, the PK2 stress is computed via the chain rule:
+
+$$\mathbf{S} = 2\frac{\partial W}{\partial \mathbf{C}} = 2\sum_{\alpha} \frac{\partial W}{\partial I_\alpha} \frac{\partial I_\alpha}{\partial \mathbf{C}}$$
+
+The invariant derivatives with respect to $\mathbf{C}$ are:
+
+| $I_\alpha$ | $\displaystyle\frac{\partial I_\alpha}{\partial \mathbf{C}}$ |
+|:----------:|:-----------------------------------------------------------:|
+| $I_1$ | $\mathbf{I}$ |
+| $I_2$ | $I_1\,\mathbf{I} - \mathbf{C}$ |
+| $I_3$ | $I_3\,\mathbf{C}^{-1}$ |
+| $I_4$ | $\mathbf{a}_0 \otimes \mathbf{a}_0$ |
+| $I_5$ | $\mathbf{a}_0 \otimes (\mathbf{C}\,\mathbf{a}_0) + (\mathbf{C}\,\mathbf{a}_0) \otimes \mathbf{a}_0$ |
+
+This is the fundamental relationship exploited in the **hybrid UMAT**: the neural network learns $W(I_\alpha)$ and its gradient $\partial W / \partial I_\alpha$, while the invariant-to-stress mapping uses the analytical expressions above.
+
+---
+
+## 8. Thermodynamic Consistency
+
+### 8.1 Requirements
+
+A hyperelastic strain energy function must satisfy:
+
+1. **Objectivity**: $W(\mathbf{Q}\mathbf{F}) = W(\mathbf{F})$ for all rotations $\mathbf{Q}$ -- guaranteed by expressing $W$ in terms of $\mathbf{C}$ (or its invariants).
+2. **Normalization**: $W(\mathbf{I}) = 0$ -- zero energy in the reference state.
+3. **Growth condition**: $W \to \infty$ as $J \to 0^+$ or $J \to \infty$ -- prevents material collapse.
+4. **Polyconvexity** (stronger than quasiconvexity): ensures existence of minimizers in boundary value problems.
+
+### 8.2 Convexity vs. Polyconvexity
+
+$W(\mathbf{F})$ is **polyconvex** if there exists a convex function $P$ such that:
+
+$$W(\mathbf{F}) = P(\mathbf{F}, \text{cof}\,\mathbf{F}, \det\,\mathbf{F})$$
+
+In terms of invariants of $\mathbf{C}$, a sufficient condition for polyconvexity is that $W$ is **separately convex** in $I_1$, $I_2$, and $J$.
+
+This is the motivation for the `PolyconvexICNN` architecture: each branch handles one invariant (or group), and the sum of convex functions is convex.
+
+---
+
+## 9. Symbolic Computation in hyper-surrogate
+
+The `SymbolicHandler` class uses **SymPy** to compute exact symbolic expressions for stress and tangent:
+
+```
+SymPy symbolic C_ij  -->  W(C)  -->  S = dW/dC  -->  C_mat = dS/dC
+         |                                                    |
+    lambdify()                                          lambdify()
+         |                                                    |
+    NumPy function  <-----  batch evaluate over N samples ---'
+```
+
+This approach:
+
+- Eliminates numerical differentiation errors
+- Enables **Common Subexpression Elimination (CSE)** for optimized Fortran code
+- Provides exact reference solutions for validating neural network surrogates
+
+---
+
+## 10. References
+
+1. **Holzapfel, G.A.** (2000). *Nonlinear Solid Mechanics: A Continuum Approach for Engineering*. Wiley.
+2. **Holzapfel, G.A., Gasser, T.C., Ogden, R.W.** (2000). A new constitutive framework for arterial wall mechanics and a comparative study of material models. *J. Elasticity*, 61, 1--48.
+3. **Gasser, T.C., Ogden, R.W., Holzapfel, G.A.** (2006). Hyperelastic modelling of arterial layers with distributed collagen fibre orientations. *J. R. Soc. Interface*, 3, 15--35.
+4. **Guccione, J.M., McCulloch, A.D., Waldman, L.K.** (1991). Passive material properties of intact ventricular myocardium determined from a cylindrical model. *J. Biomech. Eng.*, 113, 42--55.
+5. **Treloar, L.R.G.** (1944). Stress-strain data for vulcanised rubber under various types of deformation. *Trans. Faraday Soc.*, 40, 59--70.
+6. **Amos, B., Xu, L., Kolter, J.Z.** (2017). Input convex neural networks. *ICML*.
+7. **Linka, K., et al.** (2023). A new family of Constitutive Artificial Neural Networks towards automated model discovery. *CMAME*, 403, 115731.

--- a/docs/constitutive_theory.md
+++ b/docs/constitutive_theory.md
@@ -16,11 +16,11 @@ The Jacobian determinant $J = \det(\mathbf{F}) > 0$ measures volume change. For 
 
 ### 1.2 Strain Tensors
 
-| Tensor | Symbol | Definition | Configuration |
-|--------|--------|------------|---------------|
-| Right Cauchy-Green | $\mathbf{C}$ | $\mathbf{F}^T \mathbf{F}$ | Reference (Lagrangian) |
-| Left Cauchy-Green | $\mathbf{b}$ | $\mathbf{F}\, \mathbf{F}^T$ | Current (Eulerian) |
-| Green-Lagrange strain | $\mathbf{E}$ | $\frac{1}{2}(\mathbf{C} - \mathbf{I})$ | Reference |
+| Tensor                | Symbol       | Definition                             | Configuration          |
+| --------------------- | ------------ | -------------------------------------- | ---------------------- |
+| Right Cauchy-Green    | $\mathbf{C}$ | $\mathbf{F}^T \mathbf{F}$              | Reference (Lagrangian) |
+| Left Cauchy-Green     | $\mathbf{b}$ | $\mathbf{F}\, \mathbf{F}^T$            | Current (Eulerian)     |
+| Green-Lagrange strain | $\mathbf{E}$ | $\frac{1}{2}(\mathbf{C} - \mathbf{I})$ | Reference              |
 
 In `hyper-surrogate`, all constitutive evaluations are based on $\mathbf{C}$:
 
@@ -51,11 +51,11 @@ $$\mathbf{F} = J^{1/3}\, \bar{\mathbf{F}}, \qquad \bar{\mathbf{C}} = J^{-2/3}\, 
 
 The **isochoric (modified) invariants** are:
 
-| Invariant | Expression | Physical Meaning |
-|-----------|------------|-----------------|
-| $\bar{I}_1$ | $J^{-2/3}\, I_1$ | Isochoric shape change (trace) |
+| Invariant   | Expression       | Physical Meaning                  |
+| ----------- | ---------------- | --------------------------------- |
+| $\bar{I}_1$ | $J^{-2/3}\, I_1$ | Isochoric shape change (trace)    |
 | $\bar{I}_2$ | $J^{-4/3}\, I_2$ | Isochoric shape change (cofactor) |
-| $J$ | $\sqrt{I_3}$ | Volume ratio |
+| $J$         | $\sqrt{I_3}$     | Volume ratio                      |
 
 ```python
 I1_bar = hs.Kinematics.isochoric_invariant1(C)  # (N,)
@@ -122,13 +122,13 @@ $$c_{ijkl} = \frac{1}{J} F_{iI} F_{jJ} F_{kK} F_{lL}\, \mathbb{C}_{IJKL} + \text
 For FE implementation, symmetric tensors and tangent matrices are stored in Voigt notation:
 
 | Voigt Index | Tensor Components |
-|:-----------:|:-----------------:|
-| 1 | 11 (xx) |
-| 2 | 22 (yy) |
-| 3 | 33 (zz) |
-| 4 | 12 (xy) |
-| 5 | 13 (xz) |
-| 6 | 23 (yz) |
+| :---------: | :---------------: |
+|      1      |      11 (xx)      |
+|      2      |      22 (yy)      |
+|      3      |      33 (zz)      |
+|      4      |      12 (xy)      |
+|      5      |      13 (xz)      |
+|      6      |      23 (yz)      |
 
 - **Stress**: $\mathbf{S} \to [S_{11}, S_{22}, S_{33}, S_{12}, S_{13}, S_{23}]$ (6 components)
 - **Tangent**: $\mathbb{C} \to 6 \times 6$ matrix
@@ -153,12 +153,12 @@ All models share the same volumetric term:
 
 $$U(J) = \frac{K}{4}\left(J^2 - 1 - 2\ln J\right)$$
 
-| Property | Value |
-|----------|-------|
-| $U(1) = 0$ | Zero energy at $J=1$ |
-| $U'(1) = 0$ | Zero pressure at $J=1$ |
-| $U''(1) = K$ | Bulk modulus at $J=1$ |
-| $U(J) \to \infty$ as $J \to 0^+$ or $J \to \infty$ | Penalty barrier |
+| Property                                           | Value                  |
+| -------------------------------------------------- | ---------------------- |
+| $U(1) = 0$                                         | Zero energy at $J=1$   |
+| $U'(1) = 0$                                        | Zero pressure at $J=1$ |
+| $U''(1) = K$                                       | Bulk modulus at $J=1$  |
+| $U(J) \to \infty$ as $J \to 0^+$ or $J \to \infty$ | Penalty barrier        |
 
 The parameter $K$ (bulk modulus, `KBULK` in code) controls the degree of near-incompressibility. Typical values: $K = 100$--$10000 \times$ shear modulus.
 
@@ -172,10 +172,10 @@ The simplest invariant-based hyperelastic model:
 
 $$W = C_{10}(\bar{I}_1 - 3) + U(J)$$
 
-| Parameter | Symbol | Meaning | Typical Range |
-|-----------|--------|---------|---------------|
-| `C10` | $C_{10}$ | Half the initial shear modulus ($\mu/2$) | 0.1 -- 10 MPa |
-| `KBULK` | $K$ | Bulk modulus | 100 -- 10000 MPa |
+| Parameter | Symbol   | Meaning                                  | Typical Range    |
+| --------- | -------- | ---------------------------------------- | ---------------- |
+| `C10`     | $C_{10}$ | Half the initial shear modulus ($\mu/2$) | 0.1 -- 10 MPa    |
+| `KBULK`   | $K$      | Bulk modulus                             | 100 -- 10000 MPa |
 
 **Stress derivatives**:
 
@@ -194,11 +194,11 @@ Extends Neo-Hooke with dependence on the second invariant:
 
 $$W = C_{10}(\bar{I}_1 - 3) + C_{01}(\bar{I}_2 - 3) + U(J)$$
 
-| Parameter | Symbol | Meaning |
-|-----------|--------|---------|
-| `C10` | $C_{10}$ | First invariant coefficient |
-| `C01` | $C_{01}$ | Second invariant coefficient |
-| `KBULK` | $K$ | Bulk modulus |
+| Parameter | Symbol   | Meaning                      |
+| --------- | -------- | ---------------------------- |
+| `C10`     | $C_{10}$ | First invariant coefficient  |
+| `C01`     | $C_{01}$ | Second invariant coefficient |
+| `KBULK`   | $K$      | Bulk modulus                 |
 
 The initial shear modulus is $\mu = 2(C_{10} + C_{01})$.
 
@@ -215,11 +215,11 @@ Third-order polynomial in $(\bar{I}_1 - 3)$:
 
 $$W = C_{10}(\bar{I}_1 - 3) + C_{20}(\bar{I}_1 - 3)^2 + C_{30}(\bar{I}_1 - 3)^3 + U(J)$$
 
-| Parameter | Symbol | Role |
-|-----------|--------|------|
-| `C10` | $C_{10}$ | Linear (small-strain) response |
-| `C20` | $C_{20}$ | Softening at moderate strains (often $< 0$) |
-| `C30` | $C_{30}$ | Stiffening at large strains (often $> 0$) |
+| Parameter | Symbol   | Role                                        |
+| --------- | -------- | ------------------------------------------- |
+| `C10`     | $C_{10}$ | Linear (small-strain) response              |
+| `C20`     | $C_{20}$ | Softening at moderate strains (often $< 0$) |
+| `C30`     | $C_{30}$ | Stiffening at large strains (often $> 0$)   |
 
 **Use case**: Rubber undergoing large deformations with strain-stiffening. The S-shaped stress-strain curve of filled rubbers is well captured.
 
@@ -234,10 +234,10 @@ Exponential model for soft biological tissues:
 
 $$W = \frac{C_1}{C_2}\left[\exp\!\left(C_2(\bar{I}_1 - 3)\right) - 1\right] + U(J)$$
 
-| Parameter | Symbol | Role |
-|-----------|--------|------|
-| `C1` | $C_1$ | Ground-state stiffness |
-| `C2` | $C_2$ | Exponential stiffening rate |
+| Parameter | Symbol | Role                        |
+| --------- | ------ | --------------------------- |
+| `C1`      | $C_1$  | Ground-state stiffness      |
+| `C2`      | $C_2$  | Exponential stiffening rate |
 
 At small strains ($\bar{I}_1 \approx 3$), the Taylor expansion gives $W \approx C_1(\bar{I}_1 - 3)$, recovering a Neo-Hooke response.
 
@@ -256,8 +256,8 @@ $$W = \sum_{p=1}^{N} \frac{\mu_p}{\alpha_p}\left(\bar{\lambda}_1^{\alpha_p} + \b
 
 where $\bar{\lambda}_i = J^{-1/3} \lambda_i$ are the isochoric principal stretches.
 
-| Parameters | Constraint |
-|-----------|-----------|
+| Parameters              | Constraint                                                      |
+| ----------------------- | --------------------------------------------------------------- |
 | $\mu_p, \alpha_p$ pairs | $\sum_p \mu_p \alpha_p = 2\mu$ (consistency with shear modulus) |
 
 Special cases:
@@ -285,11 +285,11 @@ $$W = \frac{c}{2}\left[\exp(Q) - 1\right] + U(J)$$
 
 $$Q = b_1 E_{11}^2 + b_2(E_{22}^2 + E_{33}^2 + 2E_{12}^2)$$
 
-| Parameter | Symbol | Role |
-|-----------|--------|------|
-| `c` | $c$ | Overall stiffness scaling |
-| `b1` | $b_1$ | Axial (fiber direction) stiffening |
-| `b2` | $b_2$ | Transverse stiffening |
+| Parameter | Symbol | Role                               |
+| --------- | ------ | ---------------------------------- |
+| `c`       | $c$    | Overall stiffness scaling          |
+| `b1`      | $b_1$  | Axial (fiber direction) stiffening |
+| `b2`      | $b_2$  | Transverse stiffening              |
 
 **Use case**: Arterial tissue, especially when the exponential stiffening is important in multiple directions.
 
@@ -310,13 +310,13 @@ $$W = \underbrace{\frac{a}{2b}\left[\exp\!\left(b(\bar{I}_1 - 3)\right) - 1\righ
 
 The **Macaulay bracket** $\langle \cdot \rangle = \max(0, \cdot)$ ensures fibers only contribute under **tension** ($I_4 > 1$, i.e. the fiber is stretched).
 
-| Parameter | Symbol | Meaning |
-|-----------|--------|---------|
-| `a` | $a$ | Ground substance stiffness (kPa) |
-| `b` | $b$ | Ground substance exponential coefficient |
-| `af` | $a_f$ | Fiber stiffness (kPa) |
-| `bf` | $b_f$ | Fiber exponential coefficient |
-| `KBULK` | $K$ | Bulk modulus |
+| Parameter | Symbol | Meaning                                  |
+| --------- | ------ | ---------------------------------------- |
+| `a`       | $a$    | Ground substance stiffness (kPa)         |
+| `b`       | $b$    | Ground substance exponential coefficient |
+| `af`      | $a_f$  | Fiber stiffness (kPa)                    |
+| `bf`      | $b_f$  | Fiber exponential coefficient            |
+| `KBULK`   | $K$    | Bulk modulus                             |
 
 ```python
 from hyper_surrogate import HolzapfelOgden
@@ -336,15 +336,15 @@ where the **generalized strain invariant** accounts for dispersion:
 
 $$\bar{E} = \kappa(\bar{I}_1 - 3) + (1 - 3\kappa)(I_4 - 1)$$
 
-| $\kappa$ Value | Physical Meaning |
-|:-------------:|------------------|
-| $0$ | Perfectly aligned fibers (reduces to Holzapfel-Ogden) |
-| $1/3$ | Isotropically dispersed (no preferred direction) |
-| $0 < \kappa < 1/3$ | Partially dispersed (realistic arterial tissue) |
+|   $\kappa$ Value   | Physical Meaning                                      |
+| :----------------: | ----------------------------------------------------- |
+|        $0$         | Perfectly aligned fibers (reduces to Holzapfel-Ogden) |
+|       $1/3$        | Isotropically dispersed (no preferred direction)      |
+| $0 < \kappa < 1/3$ | Partially dispersed (realistic arterial tissue)       |
 
-| Parameter | Symbol | Meaning |
-|-----------|--------|---------|
-| `kappa` | $\kappa$ | Fiber dispersion ($0 \le \kappa \le 1/3$) |
+| Parameter | Symbol   | Meaning                                   |
+| --------- | -------- | ----------------------------------------- |
+| `kappa`   | $\kappa$ | Fiber dispersion ($0 \le \kappa \le 1/3$) |
 
 Typical values for human arteries: $\kappa \approx 0.1$--$0.3$.
 
@@ -367,12 +367,12 @@ $$Q = b_f E_{ff}^2 + b_t(E_{ss}^2 + E_{nn}^2 + 2E_{sn}^2) + b_{fs}(2E_{fs}^2 + 2
 
 where $E_{ff}, E_{ss}, E_{nn}, E_{fs}, E_{fn}, E_{sn}$ are the Green-Lagrange strain components in the local fiber ($f$), sheet ($s$), and normal ($n$) frame.
 
-| Parameter | Symbol | Role |
-|-----------|--------|------|
-| `C` | $C$ | Overall stiffness |
-| `bf` | $b_f$ | Fiber direction stiffening |
-| `bt` | $b_t$ | Transverse (sheet/normal) stiffening |
-| `bfs` | $b_{fs}$ | Fiber-sheet shear stiffening |
+| Parameter | Symbol   | Role                                 |
+| --------- | -------- | ------------------------------------ |
+| `C`       | $C$      | Overall stiffness                    |
+| `bf`      | $b_f$    | Fiber direction stiffening           |
+| `bt`      | $b_t$    | Transverse (sheet/normal) stiffening |
+| `bfs`     | $b_{fs}$ | Fiber-sheet shear stiffening         |
 
 This model requires **two** direction vectors: `fiber_direction` and `sheet_direction`. The normal direction is computed as $\mathbf{n}_0 = \mathbf{f}_0 \times \mathbf{s}_0$.
 
@@ -389,16 +389,16 @@ mat = Guccione(
 
 ## 6. Summary: Model Selection Guide
 
-| Tissue / Application | Recommended Model | Why |
-|----------------------|-------------------|-----|
-| Simple rubber (small strain) | Neo-Hooke | 1 parameter, sufficient for $< 50\%$ strain |
-| Rubber (moderate strain) | Mooney-Rivlin | 2 parameters, captures $I_2$-dependence |
-| Rubber (large strain, stiffening) | Yeoh or Ogden | Captures S-shaped stress-strain |
-| Isotropic soft tissue | Demiray | Exponential stiffening, 2 parameters |
-| Arterial wall (single fiber family) | Holzapfel-Ogden | Fiber tension-only via Macaulay bracket |
-| Arterial wall (dispersed fibers) | GOH | Adds realistic fiber dispersion |
-| Cardiac tissue | Guccione | Fiber-sheet-normal anisotropy |
-| General isotropic (data-driven fit) | Ogden ($N$-term) | Very flexible, stretch-based |
+| Tissue / Application                | Recommended Model | Why                                         |
+| ----------------------------------- | ----------------- | ------------------------------------------- |
+| Simple rubber (small strain)        | Neo-Hooke         | 1 parameter, sufficient for $< 50\%$ strain |
+| Rubber (moderate strain)            | Mooney-Rivlin     | 2 parameters, captures $I_2$-dependence     |
+| Rubber (large strain, stiffening)   | Yeoh or Ogden     | Captures S-shaped stress-strain             |
+| Isotropic soft tissue               | Demiray           | Exponential stiffening, 2 parameters        |
+| Arterial wall (single fiber family) | Holzapfel-Ogden   | Fiber tension-only via Macaulay bracket     |
+| Arterial wall (dispersed fibers)    | GOH               | Adds realistic fiber dispersion             |
+| Cardiac tissue                      | Guccione          | Fiber-sheet-normal anisotropy               |
+| General isotropic (data-driven fit) | Ogden ($N$-term)  | Very flexible, stretch-based                |
 
 ---
 
@@ -410,13 +410,13 @@ $$\mathbf{S} = 2\frac{\partial W}{\partial \mathbf{C}} = 2\sum_{\alpha} \frac{\p
 
 The invariant derivatives with respect to $\mathbf{C}$ are:
 
-| $I_\alpha$ | $\displaystyle\frac{\partial I_\alpha}{\partial \mathbf{C}}$ |
-|:----------:|:-----------------------------------------------------------:|
-| $I_1$ | $\mathbf{I}$ |
-| $I_2$ | $I_1\,\mathbf{I} - \mathbf{C}$ |
-| $I_3$ | $I_3\,\mathbf{C}^{-1}$ |
-| $I_4$ | $\mathbf{a}_0 \otimes \mathbf{a}_0$ |
-| $I_5$ | $\mathbf{a}_0 \otimes (\mathbf{C}\,\mathbf{a}_0) + (\mathbf{C}\,\mathbf{a}_0) \otimes \mathbf{a}_0$ |
+| $I_\alpha$ |                    $\displaystyle\frac{\partial I_\alpha}{\partial \mathbf{C}}$                     |
+| :--------: | :-------------------------------------------------------------------------------------------------: |
+|   $I_1$    |                                            $\mathbf{I}$                                             |
+|   $I_2$    |                                   $I_1\,\mathbf{I} - \mathbf{C}$                                    |
+|   $I_3$    |                                       $I_3\,\mathbf{C}^{-1}$                                        |
+|   $I_4$    |                                 $\mathbf{a}_0 \otimes \mathbf{a}_0$                                 |
+|   $I_5$    | $\mathbf{a}_0 \otimes (\mathbf{C}\,\mathbf{a}_0) + (\mathbf{C}\,\mathbf{a}_0) \otimes \mathbf{a}_0$ |
 
 This is the fundamental relationship exploited in the **hybrid UMAT**: the neural network learns $W(I_\alpha)$ and its gradient $\partial W / \partial I_\alpha$, while the invariant-to-stress mapping uses the analytical expressions above.
 
@@ -467,10 +467,10 @@ This approach:
 
 ## 10. References
 
-1. **Holzapfel, G.A.** (2000). *Nonlinear Solid Mechanics: A Continuum Approach for Engineering*. Wiley.
-2. **Holzapfel, G.A., Gasser, T.C., Ogden, R.W.** (2000). A new constitutive framework for arterial wall mechanics and a comparative study of material models. *J. Elasticity*, 61, 1--48.
-3. **Gasser, T.C., Ogden, R.W., Holzapfel, G.A.** (2006). Hyperelastic modelling of arterial layers with distributed collagen fibre orientations. *J. R. Soc. Interface*, 3, 15--35.
-4. **Guccione, J.M., McCulloch, A.D., Waldman, L.K.** (1991). Passive material properties of intact ventricular myocardium determined from a cylindrical model. *J. Biomech. Eng.*, 113, 42--55.
-5. **Treloar, L.R.G.** (1944). Stress-strain data for vulcanised rubber under various types of deformation. *Trans. Faraday Soc.*, 40, 59--70.
-6. **Amos, B., Xu, L., Kolter, J.Z.** (2017). Input convex neural networks. *ICML*.
-7. **Linka, K., et al.** (2023). A new family of Constitutive Artificial Neural Networks towards automated model discovery. *CMAME*, 403, 115731.
+1. **Holzapfel, G.A.** (2000). _Nonlinear Solid Mechanics: A Continuum Approach for Engineering_. Wiley.
+2. **Holzapfel, G.A., Gasser, T.C., Ogden, R.W.** (2000). A new constitutive framework for arterial wall mechanics and a comparative study of material models. _J. Elasticity_, 61, 1--48.
+3. **Gasser, T.C., Ogden, R.W., Holzapfel, G.A.** (2006). Hyperelastic modelling of arterial layers with distributed collagen fibre orientations. _J. R. Soc. Interface_, 3, 15--35.
+4. **Guccione, J.M., McCulloch, A.D., Waldman, L.K.** (1991). Passive material properties of intact ventricular myocardium determined from a cylindrical model. _J. Biomech. Eng._, 113, 42--55.
+5. **Treloar, L.R.G.** (1944). Stress-strain data for vulcanised rubber under various types of deformation. _Trans. Faraday Soc._, 40, 59--70.
+6. **Amos, B., Xu, L., Kolter, J.Z.** (2017). Input convex neural networks. _ICML_.
+7. **Linka, K., et al.** (2023). A new family of Constitutive Artificial Neural Networks towards automated model discovery. _CMAME_, 403, 115731.

--- a/docs/tutorials/advanced_topics.md
+++ b/docs/tutorials/advanced_topics.md
@@ -86,13 +86,13 @@ print(f"\nActive terms: {len(terms)} / {model._n_basis}")
 
 ### 1.5 CANN basis functions reference
 
-| Type | Function $\psi_k(I)$ | Learnable Parameters |
-|------|----------------------|---------------------|
-| Polynomial ($p=1$) | $I$ | None |
-| Polynomial ($p=2$) | $I^2$ | None |
-| Polynomial ($p=3$) | $I^3$ | None |
-| Exponential | $\exp(b \cdot I^2) - 1$ | $b > 0$ |
-| Logarithmic | $\ln(1 + I^2)$ | None |
+| Type               | Function $\psi_k(I)$    | Learnable Parameters |
+| ------------------ | ----------------------- | -------------------- |
+| Polynomial ($p=1$) | $I$                     | None                 |
+| Polynomial ($p=2$) | $I^2$                   | None                 |
+| Polynomial ($p=3$) | $I^3$                   | None                 |
+| Exponential        | $\exp(b \cdot I^2) - 1$ | $b > 0$              |
+| Logarithmic        | $\ln(1 + I^2)$          | None                 |
 
 Each basis function is applied **per invariant**, so with 3 invariants and 6 basis types, there are 18 total terms.
 
@@ -117,11 +117,11 @@ print(f"Stress range: [{data.stress.min():.3f}, {data.stress.max():.3f}] MPa")
 
 The `ExperimentalData` object contains:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `stretch` | `ndarray` | Principal stretch values $\lambda$ |
-| `stress` | `ndarray` | Corresponding engineering stress (MPa) |
-| `test_type` | `str` | Type of test (`"uniaxial"`, `"biaxial"`) |
+| Field       | Type      | Description                              |
+| ----------- | --------- | ---------------------------------------- |
+| `stretch`   | `ndarray` | Principal stretch values $\lambda$       |
+| `stress`    | `ndarray` | Corresponding engineering stress (MPa)   |
+| `test_type` | `str`     | Type of test (`"uniaxial"`, `"biaxial"`) |
 
 ### 2.2 Fitting material parameters
 
@@ -164,11 +164,11 @@ print(f"Yeoh: C10={res_ye.parameters['C10']:.4f}, "
 
 The `fit_material` function returns a `(Material, FitResult)` tuple:
 
-| `FitResult` Field | Description |
-|-------------------|-------------|
-| `parameters` | `Dict[str, float]` — fitted parameter values |
-| `r_squared` | $R^2$ goodness-of-fit (1.0 = perfect) |
-| `residual` | Sum of squared stress residuals |
+| `FitResult` Field | Description                                  |
+| ----------------- | -------------------------------------------- |
+| `parameters`      | `Dict[str, float]` — fitted parameter values |
+| `r_squared`       | $R^2$ goodness-of-fit (1.0 = perfect)        |
+| `residual`        | Sum of squared stress residuals              |
 
 The fitting minimizes:
 
@@ -178,12 +178,12 @@ using `scipy.optimize.minimize`.
 
 ### 2.4 Comparing model fits
 
-| Model | Parameters | Expected $R^2$ (Treloar) |
-|-------|:----------:|:------------------------:|
-| NeoHooke | 1 | ~0.95 (poor at large stretch) |
-| MooneyRivlin | 2 | ~0.97 |
-| Yeoh | 3 | ~0.99+ (captures stiffening) |
-| Ogden (3-term) | 6 | ~0.999 |
+| Model          | Parameters |   Expected $R^2$ (Treloar)    |
+| -------------- | :--------: | :---------------------------: |
+| NeoHooke       |     1      | ~0.95 (poor at large stretch) |
+| MooneyRivlin   |     2      |             ~0.97             |
+| Yeoh           |     3      | ~0.99+ (captures stiffening)  |
+| Ogden (3-term) |     6      |            ~0.999             |
 
 ### 2.5 Using fitted material for surrogate training
 
@@ -249,15 +249,15 @@ for r in results:
 
 Each `BenchmarkResult` contains:
 
-| Metric | Description |
-|--------|-------------|
-| Material name | Which material was tested |
-| Model name | Which architecture was used |
-| $R^2$ | Coefficient of determination on test set |
-| MAE | Mean absolute error |
-| RMSE | Root mean squared error |
-| Training time | Wall-clock time for training |
-| Best epoch | Epoch with best validation loss |
+| Metric        | Description                              |
+| ------------- | ---------------------------------------- |
+| Material name | Which material was tested                |
+| Model name    | Which architecture was used              |
+| $R^2$         | Coefficient of determination on test set |
+| MAE           | Mean absolute error                      |
+| RMSE          | Root mean squared error                  |
+| Training time | Wall-clock time for training             |
+| Best epoch    | Epoch with best validation loss          |
 
 ### 3.3 Example output
 
@@ -353,13 +353,13 @@ reporter.generate_report("report_from_F/")
 
 ### 4.6 What to look for in diagnostic reports
 
-| Check | What It Tells You |
-|-------|-------------------|
-| $\bar{I}_1$ near 3 | Deformations are moderate (good for most materials) |
-| $J$ spread | Volumetric perturbation range (should match your material's compressibility) |
-| $\lambda_1 / \lambda_3$ ratio | Maximum stretch anisotropy |
-| Bimodal $\lambda$ distribution | Mix of tension and compression modes |
-| Uniform $J$ histogram | Even volumetric sampling |
+| Check                          | What It Tells You                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------- |
+| $\bar{I}_1$ near 3             | Deformations are moderate (good for most materials)                          |
+| $J$ spread                     | Volumetric perturbation range (should match your material's compressibility) |
+| $\lambda_1 / \lambda_3$ ratio  | Maximum stretch anisotropy                                                   |
+| Bimodal $\lambda$ distribution | Mix of tension and compression modes                                         |
+| Uniform $J$ histogram          | Even volumetric sampling                                                     |
 
 ---
 

--- a/docs/tutorials/advanced_topics.md
+++ b/docs/tutorials/advanced_topics.md
@@ -1,0 +1,434 @@
+# Advanced Topics
+
+This tutorial covers model discovery with CANN, parameter fitting to experimental data, benchmarking surrogates, and generating deformation diagnostic reports.
+
+---
+
+## 1. Model Discovery with CANN
+
+The **Constitutive Artificial Neural Network (CANN)** uses interpretable basis functions with learnable non-negative weights. Combined with L1 regularization, it discovers the **minimal constitutive law** from data.
+
+### 1.1 The idea
+
+Instead of a black-box NN, CANN expresses the energy as:
+
+$$W = \sum_{k} \underbrace{\text{softplus}(w_k)}_{\ge 0} \cdot \psi_k(I_\alpha)$$
+
+After training with sparsity regularization, most weights $w_k \to 0$. The surviving terms reveal the underlying constitutive law.
+
+### 1.2 Setting up a CANN
+
+```python
+from hyper_surrogate.models.cann import CANN
+from hyper_surrogate.data.dataset import create_datasets
+from hyper_surrogate.mechanics.materials import NeoHooke
+
+# Generate data from a known material (ground truth)
+material = NeoHooke(parameters={"C10": 0.5, "KBULK": 1000.0})
+train_ds, val_ds, in_norm, out_norm = create_datasets(
+    material, n_samples=5000,
+    input_type="invariants", target_type="energy", seed=42,
+)
+
+# Create CANN with diverse basis functions
+model = CANN(
+    input_dim=train_ds.inputs.shape[1],  # 3 (I1_bar, I2_bar, J)
+    n_polynomial=3,       # (I)^1, (I)^2, (I)^3 per invariant
+    n_exponential=2,      # exp(b·I²) - 1 per invariant (learnable b)
+    use_logarithmic=True, # log(1 + I²) per invariant
+    learnable_exponents=True,
+)
+
+print(f"Total basis functions: {model._n_basis}")
+```
+
+### 1.3 Training with sparsity
+
+```python
+from hyper_surrogate.training.losses import SparseLoss
+from hyper_surrogate.training.trainer import Trainer
+
+# SparseLoss = EnergyStressLoss + L1 regularization
+loss_fn = SparseLoss(alpha=1.0, beta=1.0, l1_lambda=0.01)
+
+result = Trainer(
+    model, train_ds, val_ds,
+    loss_fn=loss_fn,
+    max_epochs=500,
+    lr=1e-3,
+).fit()
+
+print(f"Final val loss: {result.history['val_loss'][-1]:.6f}")
+```
+
+### 1.4 Inspecting discovered terms
+
+```python
+# Get active (non-zero) basis functions
+terms = model.get_active_terms(threshold=0.01)
+
+print("Discovered constitutive law:")
+for t in terms:
+    inv_name = f"I{t['invariant'] + 1}_bar" if t["invariant"] < 2 else "J"
+    w = t["weight"]
+
+    if t["type"] == "polynomial":
+        print(f"  w={w:.4f} * ({inv_name})^{t['power']}")
+    elif t["type"] == "exponential":
+        print(f"  w={w:.4f} * [exp({t['stiffness']:.3f} * {inv_name}^2) - 1]")
+    elif t["type"] == "logarithmic":
+        print(f"  w={w:.4f} * log(1 + {inv_name}^2)")
+
+print(f"\nActive terms: {len(terms)} / {model._n_basis}")
+```
+
+**Expected output for NeoHooke** ($W = C_{10}(\bar{I}_1 - 3)$): the dominant term should be a linear polynomial in $\bar{I}_1$.
+
+### 1.5 CANN basis functions reference
+
+| Type | Function $\psi_k(I)$ | Learnable Parameters |
+|------|----------------------|---------------------|
+| Polynomial ($p=1$) | $I$ | None |
+| Polynomial ($p=2$) | $I^2$ | None |
+| Polynomial ($p=3$) | $I^3$ | None |
+| Exponential | $\exp(b \cdot I^2) - 1$ | $b > 0$ |
+| Logarithmic | $\ln(1 + I^2)$ | None |
+
+Each basis function is applied **per invariant**, so with 3 invariants and 6 basis types, there are 18 total terms.
+
+---
+
+## 2. Parameter Fitting to Experimental Data
+
+### 2.1 Loading experimental data
+
+`hyper-surrogate` includes the classic **Treloar (1944)** rubber dataset:
+
+```python
+from hyper_surrogate.data.experimental import ExperimentalData
+
+# Load built-in reference dataset
+data = ExperimentalData.load_reference("treloar")
+
+print(f"Data points: {len(data.stretch)}")
+print(f"Stretch range: [{data.stretch.min():.2f}, {data.stretch.max():.2f}]")
+print(f"Stress range: [{data.stress.min():.3f}, {data.stress.max():.3f}] MPa")
+```
+
+The `ExperimentalData` object contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stretch` | `ndarray` | Principal stretch values $\lambda$ |
+| `stress` | `ndarray` | Corresponding engineering stress (MPa) |
+| `test_type` | `str` | Type of test (`"uniaxial"`, `"biaxial"`) |
+
+### 2.2 Fitting material parameters
+
+```python
+from hyper_surrogate.data.fitting import fit_material
+from hyper_surrogate.mechanics.materials import NeoHooke, MooneyRivlin, Yeoh
+
+# Fit Neo-Hooke
+mat_nh, res_nh = fit_material(
+    NeoHooke,
+    data,
+    initial_guess={"C10": 0.1},
+    fixed_params={"KBULK": 1000.0},
+)
+print(f"NeoHooke: C10={res_nh.parameters['C10']:.4f}, R²={res_nh.r_squared:.4f}")
+
+# Fit Mooney-Rivlin
+mat_mr, res_mr = fit_material(
+    MooneyRivlin,
+    data,
+    initial_guess={"C10": 0.1, "C01": 0.05},
+    fixed_params={"KBULK": 1000.0},
+)
+print(f"MooneyRivlin: C10={res_mr.parameters['C10']:.4f}, "
+      f"C01={res_mr.parameters['C01']:.4f}, R²={res_mr.r_squared:.4f}")
+
+# Fit Yeoh
+mat_ye, res_ye = fit_material(
+    Yeoh,
+    data,
+    initial_guess={"C10": 0.1, "C20": 0.001, "C30": 0.0001},
+    fixed_params={"KBULK": 1000.0},
+)
+print(f"Yeoh: C10={res_ye.parameters['C10']:.4f}, "
+      f"C20={res_ye.parameters['C20']:.6f}, "
+      f"C30={res_ye.parameters['C30']:.8f}, R²={res_ye.r_squared:.4f}")
+```
+
+### 2.3 Understanding the fitting result
+
+The `fit_material` function returns a `(Material, FitResult)` tuple:
+
+| `FitResult` Field | Description |
+|-------------------|-------------|
+| `parameters` | `Dict[str, float]` — fitted parameter values |
+| `r_squared` | $R^2$ goodness-of-fit (1.0 = perfect) |
+| `residual` | Sum of squared stress residuals |
+
+The fitting minimizes:
+
+$$\min_{\theta} \sum_i \|\sigma_{\text{model}}(\lambda_i; \theta) - \sigma_{\text{exp},i}\|^2$$
+
+using `scipy.optimize.minimize`.
+
+### 2.4 Comparing model fits
+
+| Model | Parameters | Expected $R^2$ (Treloar) |
+|-------|:----------:|:------------------------:|
+| NeoHooke | 1 | ~0.95 (poor at large stretch) |
+| MooneyRivlin | 2 | ~0.97 |
+| Yeoh | 3 | ~0.99+ (captures stiffening) |
+| Ogden (3-term) | 6 | ~0.999 |
+
+### 2.5 Using fitted material for surrogate training
+
+```python
+# Use the fitted material directly in the surrogate pipeline
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    mat_ye,  # Fitted Yeoh material
+    n_samples=10000,
+    input_type="invariants",
+    target_type="energy",
+)
+# ... train NN as usual ...
+```
+
+---
+
+## 3. Benchmarking Surrogates
+
+### 3.1 Using the benchmark suite
+
+The `benchmark_suite` function systematically compares architectures across materials:
+
+```python
+from hyper_surrogate.benchmarking.metrics import benchmark_suite
+from hyper_surrogate.benchmarking.reporting import results_to_markdown
+from hyper_surrogate.mechanics.materials import NeoHooke, MooneyRivlin, Yeoh
+from hyper_surrogate.models.mlp import MLP
+from hyper_surrogate.models.icnn import ICNN
+from hyper_surrogate.training.losses import StressLoss
+
+materials = [NeoHooke(), MooneyRivlin(), Yeoh()]
+
+model_configs = [
+    {
+        "name": "MLP-64x64",
+        "model_cls": MLP,
+        "kwargs": {"hidden_dims": [64, 64], "activation": "tanh"},
+        "loss_cls": StressLoss,
+        "epochs": 200,
+        "target_type": "pk2_voigt",
+    },
+    {
+        "name": "ICNN-64x64",
+        "model_cls": ICNN,
+        "kwargs": {"hidden_dims": [64, 64]},
+        "loss_cls": StressLoss,
+        "epochs": 200,
+        "target_type": "pk2_voigt",
+    },
+]
+
+results = benchmark_suite(materials, model_configs, n_samples=5000, seed=42)
+
+# Pretty-print as markdown table
+print(results_to_markdown(results))
+
+# Per-result details
+for r in results:
+    print(r.summary())
+```
+
+### 3.2 Benchmark metrics
+
+Each `BenchmarkResult` contains:
+
+| Metric | Description |
+|--------|-------------|
+| Material name | Which material was tested |
+| Model name | Which architecture was used |
+| $R^2$ | Coefficient of determination on test set |
+| MAE | Mean absolute error |
+| RMSE | Root mean squared error |
+| Training time | Wall-clock time for training |
+| Best epoch | Epoch with best validation loss |
+
+### 3.3 Example output
+
+```
+| Material     | Model      | R²      | MAE     | RMSE    | Time (s) |
+|-------------|------------|---------|---------|---------|----------|
+| NeoHooke    | MLP-64x64  | 0.9998  | 0.0012  | 0.0018  | 12.3     |
+| NeoHooke    | ICNN-64x64 | 0.9995  | 0.0019  | 0.0025  | 15.1     |
+| MooneyRivlin| MLP-64x64  | 0.9997  | 0.0015  | 0.0021  | 13.0     |
+| MooneyRivlin| ICNN-64x64 | 0.9993  | 0.0022  | 0.0030  | 16.2     |
+| Yeoh        | MLP-64x64  | 0.9996  | 0.0018  | 0.0024  | 13.5     |
+| Yeoh        | ICNN-64x64 | 0.9991  | 0.0026  | 0.0035  | 17.0     |
+```
+
+---
+
+## 4. Deformation Reporting
+
+### 4.1 Generating diagnostic reports
+
+The `Reporter` class creates visualizations of your deformation data to verify coverage and quality:
+
+```python
+import numpy as np
+from hyper_surrogate.data.deformation import DeformationGenerator
+from hyper_surrogate.mechanics.kinematics import Kinematics
+from hyper_surrogate.reporting.reporter import Reporter
+
+# Generate data
+gen = DeformationGenerator(seed=42)
+F = gen.combined(n=5000, stretch_range=(0.8, 1.3), shear_range=(-0.2, 0.2))
+C = Kinematics.right_cauchy_green(F)
+
+# Create reporter
+reporter = Reporter(C)
+```
+
+### 4.2 Individual plots
+
+```python
+# Eigenvalue distribution of C (per component)
+reporter.fig_eigenvalues()
+
+# Determinant det(C) = J² histogram
+reporter.fig_determinants()
+
+# Isochoric invariants: I1_bar, I2_bar, J
+reporter.fig_invariants()
+
+# Principal stretches λ1 ≥ λ2 ≥ λ3
+reporter.fig_principal_stretches()
+
+# Volume change ratio J
+reporter.fig_volume_change()
+```
+
+### 4.3 Summary statistics
+
+```python
+stats = reporter.basic_statistics()
+for key, val in stats.items():
+    print(f"{key:>20s}: mean={val['mean']:8.4f}, std={val['std']:8.4f}, "
+          f"min={val['min']:8.4f}, max={val['max']:8.4f}")
+```
+
+Example output:
+
+```
+           I1_bar:  mean=  3.0842, std=  0.1523, min=  2.7601, max=  3.9214
+           I2_bar:  mean=  3.1056, std=  0.1891, min=  2.7012, max=  4.2103
+               J:  mean=  1.0000, std=  0.0001, min=  0.9998, max=  1.0002
+         lambda1:  mean=  1.1203, std=  0.0812, min=  0.8521, max=  1.4012
+         lambda2:  mean=  1.0012, std=  0.0534, min=  0.8102, max=  1.2503
+         lambda3:  mean=  0.8956, std=  0.0612, min=  0.7201, max=  1.1203
+```
+
+### 4.4 Full PDF report
+
+```python
+# Generate all figures as a combined report
+reporter.generate_report("deformation_report/")
+# Creates: deformation_report/ with all figures as PNG + summary
+```
+
+### 4.5 From deformation gradients
+
+You can also pass $\mathbf{F}$ directly:
+
+```python
+reporter = Reporter(F, tensor_type="F")  # Computes C = F^T F internally
+reporter.generate_report("report_from_F/")
+```
+
+### 4.6 What to look for in diagnostic reports
+
+| Check | What It Tells You |
+|-------|-------------------|
+| $\bar{I}_1$ near 3 | Deformations are moderate (good for most materials) |
+| $J$ spread | Volumetric perturbation range (should match your material's compressibility) |
+| $\lambda_1 / \lambda_3$ ratio | Maximum stretch anisotropy |
+| Bimodal $\lambda$ distribution | Mix of tension and compression modes |
+| Uniform $J$ histogram | Even volumetric sampling |
+
+---
+
+## 5. Workflow Recipes
+
+### Recipe: From experimental data to Fortran UMAT
+
+```python
+import hyper_surrogate as hs
+from hyper_surrogate.data.experimental import ExperimentalData
+from hyper_surrogate.data.fitting import fit_material
+from hyper_surrogate.mechanics.materials import Yeoh
+
+# 1. Load and fit
+data = ExperimentalData.load_reference("treloar")
+material, fit_result = fit_material(
+    Yeoh, data,
+    initial_guess={"C10": 0.1, "C20": 0.001, "C30": 0.0001},
+    fixed_params={"KBULK": 1000.0},
+)
+print(f"Fit R² = {fit_result.r_squared:.4f}")
+
+# 2. Generate surrogate training data
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material, n_samples=10000,
+    input_type="invariants", target_type="energy",
+)
+
+# 3. Train
+model = hs.ICNN(input_dim=3, hidden_dims=[64, 64])
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=2000, lr=1e-3, patience=200,
+).fit()
+
+# 4. Export
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+hs.HybridUMATEmitter(exported).write("yeoh_surrogate_umat.f90")
+```
+
+### Recipe: Analytical UMAT (no NN)
+
+```python
+from hyper_surrogate.mechanics.materials import MooneyRivlin
+from hyper_surrogate.export.fortran.analytical import UMATHandler
+
+material = MooneyRivlin({"C10": 0.3, "C01": 0.2, "KBULK": 1000.0})
+UMATHandler(material).generate("mooneyrivlin_umat.f")
+```
+
+### Recipe: Model discovery pipeline
+
+```python
+from hyper_surrogate.models.cann import CANN
+from hyper_surrogate.training.losses import SparseLoss
+
+# 1. Train CANN with sparsity
+model = CANN(input_dim=3, n_polynomial=3, n_exponential=2, use_logarithmic=True)
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=SparseLoss(alpha=1.0, beta=1.0, l1_lambda=0.01),
+    max_epochs=500,
+).fit()
+
+# 2. Identify active terms
+terms = model.get_active_terms(threshold=0.01)
+print(f"Discovered {len(terms)} active terms out of {model._n_basis}")
+
+# 3. Use discovered structure to select a simpler analytical model
+# e.g., if only I1_bar polynomial terms survive → NeoHooke or Yeoh
+```

--- a/docs/tutorials/anisotropic_materials.md
+++ b/docs/tutorials/anisotropic_materials.md
@@ -8,10 +8,10 @@ This tutorial covers modeling fiber-reinforced biological tissues — from singl
 
 Anisotropic hyperelastic materials have a **preferred direction** (fiber) that makes the mechanical response direction-dependent. In `hyper-surrogate`, anisotropy is introduced via fiber (pseudo-)invariants:
 
-| Invariant | Expression | Physical Meaning |
-|-----------|-----------|-----------------|
-| $I_4$ | $\mathbf{a}_0 \cdot \mathbf{C}\, \mathbf{a}_0$ | Squared fiber stretch ($\lambda_f^2$) |
-| $I_5$ | $\mathbf{a}_0 \cdot \mathbf{C}^2\, \mathbf{a}_0$ | Fiber-shear coupling |
+| Invariant | Expression                                       | Physical Meaning                      |
+| --------- | ------------------------------------------------ | ------------------------------------- |
+| $I_4$     | $\mathbf{a}_0 \cdot \mathbf{C}\, \mathbf{a}_0$   | Squared fiber stretch ($\lambda_f^2$) |
+| $I_5$     | $\mathbf{a}_0 \cdot \mathbf{C}^2\, \mathbf{a}_0$ | Fiber-shear coupling                  |
 
 The NN input becomes **5-dimensional**: $[\bar{I}_1, \bar{I}_2, J, I_4, I_5]$ instead of 3D for isotropic materials.
 
@@ -152,12 +152,12 @@ The Gasser-Ogden-Holzapfel model adds a **dispersion parameter** $\kappa$ that b
 
 $$\bar{E} = \kappa(\bar{I}_1 - 3) + (1 - 3\kappa)(I_4 - 1)$$
 
-| $\kappa$ | Interpretation |
-|:--------:|----------------|
-| $0$ | Perfectly aligned (= Holzapfel-Ogden) |
-| $0.1$ | Slightly dispersed |
-| $0.226$ | Moderate dispersion (typical arterial media) |
-| $1/3$ | Fully isotropic (no preferred direction) |
+| $\kappa$ | Interpretation                               |
+| :------: | -------------------------------------------- |
+|   $0$    | Perfectly aligned (= Holzapfel-Ogden)        |
+|  $0.1$   | Slightly dispersed                           |
+| $0.226$  | Moderate dispersion (typical arterial media) |
+|  $1/3$   | Fully isotropic (no preferred direction)     |
 
 ```python
 from hyper_surrogate.mechanics.materials import GasserOgdenHolzapfel
@@ -259,12 +259,12 @@ for lam in stretches:
 
 ### 3.4 Important notes for multi-fiber models
 
-| Aspect | Guideline |
-|--------|-----------|
-| **Double-counting** | The isotropic + volumetric parts must only be counted once |
-| **Symmetry** | For symmetric fiber families, $W_{\text{fiber,1}}(\theta) = W_{\text{fiber,2}}(-\theta)$ under symmetric loading |
-| **Macaulay bracket** | Fibers only contribute under tension ($I_4 > 1$) |
-| **NN approach** | Train separate NNs per fiber family, or one NN with all fiber invariants as inputs |
+| Aspect               | Guideline                                                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Double-counting**  | The isotropic + volumetric parts must only be counted once                                                       |
+| **Symmetry**         | For symmetric fiber families, $W_{\text{fiber,1}}(\theta) = W_{\text{fiber,2}}(-\theta)$ under symmetric loading |
+| **Macaulay bracket** | Fibers only contribute under tension ($I_4 > 1$)                                                                 |
+| **NN approach**      | Train separate NNs per fiber family, or one NN with all fiber invariants as inputs                               |
 
 ---
 
@@ -310,11 +310,11 @@ print(f"PK2 S33 (normal): {pk2[0, 2, 2]:.6f}")
 
 ### Physical interpretation of Guccione parameters
 
-| Parameter | Large value means... |
-|-----------|---------------------|
-| $b_f$ | Stiffer in fiber direction |
-| $b_t$ | Stiffer transversely (sheet & normal) |
-| $b_{fs}$ | Stiffer in fiber-sheet shear |
+| Parameter | Large value means...                  |
+| --------- | ------------------------------------- |
+| $b_f$     | Stiffer in fiber direction            |
+| $b_t$     | Stiffer transversely (sheet & normal) |
+| $b_{fs}$  | Stiffer in fiber-sheet shear          |
 
 Typical hierarchy: $b_f > b_t > b_{fs}$ (myocardium is stiffest along fibers).
 
@@ -364,17 +364,17 @@ fibers = gen.fiber_directions(
 
 ## 6. Summary: Anisotropic Model Comparison
 
-| Model | Fiber Families | Directions Needed | Key Feature | Application |
-|-------|:--------------:|:-----------------:|-------------|-------------|
-| **HolzapfelOgden** | 1 | `fiber_direction` | Macaulay bracket (tension-only) | Arterial media |
-| **GOH** | 1 | `fiber_direction` | Dispersion parameter $\kappa$ | Arterial adventitia |
-| **Guccione** | 1 | `fiber_direction` + `sheet_direction` | Fiber-sheet-normal frame | Myocardium |
-| **Two-fiber** | 2 | Two `fiber_direction`s | Combined energy (avoid double-counting) | Full arterial wall |
+| Model              | Fiber Families |           Directions Needed           | Key Feature                             | Application         |
+| ------------------ | :------------: | :-----------------------------------: | --------------------------------------- | ------------------- |
+| **HolzapfelOgden** |       1        |           `fiber_direction`           | Macaulay bracket (tension-only)         | Arterial media      |
+| **GOH**            |       1        |           `fiber_direction`           | Dispersion parameter $\kappa$           | Arterial adventitia |
+| **Guccione**       |       1        | `fiber_direction` + `sheet_direction` | Fiber-sheet-normal frame                | Myocardium          |
+| **Two-fiber**      |       2        |        Two `fiber_direction`s         | Combined energy (avoid double-counting) | Full arterial wall  |
 
 ### NN input dimensions
 
-| Model Type | Input Dim | Components |
-|-----------|:---------:|-----------|
-| Isotropic | 3 | $\bar{I}_1, \bar{I}_2, J$ |
-| Single fiber | 5 | $\bar{I}_1, \bar{I}_2, J, I_4, I_5$ |
-| Two fibers | 7 | $\bar{I}_1, \bar{I}_2, J, I_4^{(1)}, I_5^{(1)}, I_4^{(2)}, I_5^{(2)}$ |
+| Model Type   | Input Dim | Components                                                            |
+| ------------ | :-------: | --------------------------------------------------------------------- |
+| Isotropic    |     3     | $\bar{I}_1, \bar{I}_2, J$                                             |
+| Single fiber |     5     | $\bar{I}_1, \bar{I}_2, J, I_4, I_5$                                   |
+| Two fibers   |     7     | $\bar{I}_1, \bar{I}_2, J, I_4^{(1)}, I_5^{(1)}, I_4^{(2)}, I_5^{(2)}$ |

--- a/docs/tutorials/anisotropic_materials.md
+++ b/docs/tutorials/anisotropic_materials.md
@@ -1,0 +1,380 @@
+# Anisotropic Materials
+
+This tutorial covers modeling fiber-reinforced biological tissues — from single-fiber arterial models to multi-fiber cardiac tissue — including data generation, training, and Fortran export for anisotropic materials.
+
+---
+
+## Overview
+
+Anisotropic hyperelastic materials have a **preferred direction** (fiber) that makes the mechanical response direction-dependent. In `hyper-surrogate`, anisotropy is introduced via fiber (pseudo-)invariants:
+
+| Invariant | Expression | Physical Meaning |
+|-----------|-----------|-----------------|
+| $I_4$ | $\mathbf{a}_0 \cdot \mathbf{C}\, \mathbf{a}_0$ | Squared fiber stretch ($\lambda_f^2$) |
+| $I_5$ | $\mathbf{a}_0 \cdot \mathbf{C}^2\, \mathbf{a}_0$ | Fiber-shear coupling |
+
+The NN input becomes **5-dimensional**: $[\bar{I}_1, \bar{I}_2, J, I_4, I_5]$ instead of 3D for isotropic materials.
+
+---
+
+## 1. Holzapfel-Ogden: Single Fiber Family
+
+### 1.1 Model definition
+
+```python
+import numpy as np
+import hyper_surrogate as hs
+
+fiber_dir = np.array([1.0, 0.0, 0.0])  # Fiber along x-axis
+
+material = hs.HolzapfelOgden(
+    parameters={
+        "a": 0.059,     # Ground substance stiffness (kPa)
+        "b": 8.023,     # Ground substance exponent
+        "af": 18.472,   # Fiber stiffness (kPa)
+        "bf": 16.026,   # Fiber exponent
+        "KBULK": 1000.0,
+    },
+    fiber_direction=fiber_dir,
+)
+```
+
+### 1.2 Evaluating stress
+
+```python
+from hyper_surrogate.mechanics.kinematics import Kinematics
+
+# Uniaxial stretch along fiber direction
+lam = 1.15
+F = np.array([[[lam, 0, 0],
+               [0, 1.0/np.sqrt(lam), 0],
+               [0, 0, 1.0/np.sqrt(lam)]]])
+
+C = Kinematics.right_cauchy_green(F)
+pk2 = material.evaluate_pk2(C)       # (1, 3, 3)
+energy = material.evaluate_energy(C)  # (1,)
+
+print(f"Energy: {energy[0]:.6f}")
+print(f"PK2 S11 (fiber dir): {pk2[0, 0, 0]:.6f}")
+print(f"PK2 S22 (transverse): {pk2[0, 1, 1]:.6f}")
+```
+
+Note the **anisotropy**: $S_{11} \gg S_{22}$ because of the fiber contribution along axis 1.
+
+### 1.3 Computing fiber invariants
+
+```python
+gen = hs.DeformationGenerator(seed=42)
+F_batch = gen.combined(n=5000, stretch_range=(0.8, 1.3))
+C_batch = Kinematics.right_cauchy_green(F_batch)
+
+# Isochoric invariants
+i1 = Kinematics.isochoric_invariant1(C_batch)
+i2 = Kinematics.isochoric_invariant2(C_batch)
+j = np.sqrt(Kinematics.det_invariant(C_batch))
+
+# Fiber invariants
+i4 = Kinematics.fiber_invariant4(C_batch, fiber_dir)
+i5 = Kinematics.fiber_invariant5(C_batch, fiber_dir)
+
+# 5D input for NN
+inputs = np.column_stack([i1, i2, j, i4, i5])
+print(f"Input shape: {inputs.shape}")  # (5000, 5)
+print(f"I4 range: [{i4.min():.3f}, {i4.max():.3f}]")
+print(f"I5 range: [{i5.min():.3f}, {i5.max():.3f}]")
+```
+
+### 1.4 Full training pipeline
+
+```python
+from hyper_surrogate.data.dataset import MaterialDataset, Normalizer
+
+n = 10000
+F = gen.combined(n, stretch_range=(0.8, 1.3), shear_range=(-0.2, 0.2))
+
+# Add volumetric perturbation
+rng = np.random.default_rng(99)
+J_target = rng.uniform(0.95, 1.05, size=n)
+F = F * (J_target / np.linalg.det(F))[:, None, None] ** (1.0 / 3.0)
+C = Kinematics.right_cauchy_green(F)
+
+# 5D invariants
+i1 = Kinematics.isochoric_invariant1(C)
+i2 = Kinematics.isochoric_invariant2(C)
+j = np.sqrt(Kinematics.det_invariant(C))
+i4 = Kinematics.fiber_invariant4(C, fiber_dir)
+i5 = Kinematics.fiber_invariant5(C, fiber_dir)
+inputs = np.column_stack([i1, i2, j, i4, i5])
+
+# Energy and gradient targets (5 components)
+energy = material.evaluate_energy(C)
+dW_dI = material.evaluate_energy_grad_invariants(C)  # (N, 5)
+
+# Normalize
+in_norm = Normalizer().fit(inputs)
+X = in_norm.transform(inputs).astype(np.float32)
+W = energy.reshape(-1, 1).astype(np.float32)
+S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+# Split
+n_val = int(n * 0.15)
+idx = np.random.default_rng(42).permutation(n)
+train_ds = MaterialDataset(X[idx[n_val:]], (W[idx[n_val:]], S[idx[n_val:]]))
+val_ds = MaterialDataset(X[idx[:n_val]], (W[idx[:n_val]], S[idx[:n_val]]))
+
+# Train with 5 inputs
+model = hs.MLP(input_dim=5, output_dim=1, hidden_dims=[64, 64, 64], activation="softplus")
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=3000, lr=1e-3, patience=300, batch_size=512,
+).fit()
+
+print(f"Best val loss: {result.history['val_loss'][result.best_epoch]:.6f}")
+
+# Export hybrid UMAT (auto-detects 5D → anisotropic)
+energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+exported = hs.extract_weights(result.model, in_norm, energy_norm)
+hs.HybridUMATEmitter(exported).write("holzapfel_ogden_umat.f90")
+```
+
+The `HybridUMATEmitter` detects `input_dim=5` and generates Fortran code that:
+
+- Reads the fiber direction from `PROPS(1:3)`
+- Computes $I_4, I_5$ from $\mathbf{C}$ and $\mathbf{a}_0$
+- Includes $\partial I_4 / \partial \mathbf{C}$ and $\partial I_5 / \partial \mathbf{C}$ for the stress chain rule
+
+---
+
+## 2. GOH: Dispersed Fibers
+
+The Gasser-Ogden-Holzapfel model adds a **dispersion parameter** $\kappa$ that blends fiber and isotropic contributions:
+
+$$\bar{E} = \kappa(\bar{I}_1 - 3) + (1 - 3\kappa)(I_4 - 1)$$
+
+| $\kappa$ | Interpretation |
+|:--------:|----------------|
+| $0$ | Perfectly aligned (= Holzapfel-Ogden) |
+| $0.1$ | Slightly dispersed |
+| $0.226$ | Moderate dispersion (typical arterial media) |
+| $1/3$ | Fully isotropic (no preferred direction) |
+
+```python
+from hyper_surrogate.mechanics.materials import GasserOgdenHolzapfel
+
+mat_goh = GasserOgdenHolzapfel(
+    parameters={
+        "a": 0.059, "b": 8.023,
+        "af": 18.472, "bf": 16.026,
+        "kappa": 0.226,
+        "KBULK": 1000.0,
+    },
+    fiber_direction=np.array([1.0, 0.0, 0.0]),
+)
+
+# Same workflow: evaluate_pk2, evaluate_energy, etc.
+pk2 = mat_goh.evaluate_pk2(C)
+energy = mat_goh.evaluate_energy(C)
+```
+
+---
+
+## 3. Two-Fiber Arterial Wall Model
+
+Real arteries have **two families** of collagen fibers oriented symmetrically at angles $\pm\theta$ from the circumferential direction.
+
+### 3.1 Setup
+
+```python
+import numpy as np
+from hyper_surrogate.mechanics.materials import GasserOgdenHolzapfel
+from hyper_surrogate.mechanics.kinematics import Kinematics
+
+# Two fiber families at ±39° from circumferential (x-axis)
+theta = np.radians(39.0)
+fiber1 = np.array([np.cos(theta), np.sin(theta), 0.0])
+fiber2 = np.array([np.cos(theta), -np.sin(theta), 0.0])
+
+# Medial layer parameters (Holzapfel et al., 2005)
+params = {
+    "a": 3.0,       # kPa
+    "b": 0.5,
+    "af": 2.3632,   # kPa
+    "bf": 0.8393,
+    "kappa": 0.226,
+    "KBULK": 100.0,
+}
+
+mat1 = GasserOgdenHolzapfel(parameters=params, fiber_direction=fiber1)
+mat2 = GasserOgdenHolzapfel(parameters=params, fiber_direction=fiber2)
+```
+
+### 3.2 Combining two fiber families
+
+The total energy avoids double-counting the isotropic ground substance:
+
+$$W_{\text{total}} = \underbrace{W_{\text{iso}} + W_{\text{vol}}}_{\text{shared (from fiber 1)}} + \underbrace{W_{\text{fiber,1}}}_{\text{fiber 1}} + \underbrace{W_{\text{fiber,2}}}_{\text{fiber 2}}$$
+
+```python
+from sympy import Symbol, lambdify
+
+# Symbolic invariants
+i1s, i2s, js = Symbol("I1b"), Symbol("I2b"), Symbol("J")
+i4s_1, i5s_1 = Symbol("I4_1"), Symbol("I5_1")
+i4s_2, i5s_2 = Symbol("I4_2"), Symbol("I5_2")
+
+# Full energy from fiber family 1 (isotropic + volumetric + fiber)
+W1_full = mat1.sef_from_invariants(i1s, i2s, js, i4s_1, i5s_1)
+
+# Fiber-only contribution from family 2
+W2_full = mat2.sef_from_invariants(i1s, i2s, js, i4s_2, i5s_2)
+W2_iso = mat2.sef_from_invariants(i1s, i2s, js)  # iso + vol only
+W2_fiber = W2_full - W2_iso  # fiber contribution only
+
+W_total = W1_full + W2_fiber
+```
+
+### 3.3 Evaluating under equibiaxial stretch
+
+```python
+stretches = np.linspace(1.0, 1.3, 10)
+
+print(f"{'Stretch':>8s} {'W_total':>12s} {'I4_fib1':>10s} {'I4_fib2':>10s}")
+print("-" * 45)
+
+for lam in stretches:
+    F = np.array([[[lam, 0, 0], [0, lam, 0], [0, 0, 1.0/(lam*lam)]]])
+    C = Kinematics.right_cauchy_green(F)
+
+    i4_1 = Kinematics.fiber_invariant4(C, fiber1)
+    i4_2 = Kinematics.fiber_invariant4(C, fiber2)
+
+    W1 = mat1.evaluate_energy(C)
+    W2 = mat2.evaluate_energy(C)
+    # Total = W1 (includes iso+vol) + fiber-only from mat2
+    # For approximate evaluation, sum both energies and subtract one iso+vol contribution
+
+    print(f"{lam:8.3f} {float(W1 + W2):12.4f} {float(i4_1):10.4f} {float(i4_2):10.4f}")
+```
+
+### 3.4 Important notes for multi-fiber models
+
+| Aspect | Guideline |
+|--------|-----------|
+| **Double-counting** | The isotropic + volumetric parts must only be counted once |
+| **Symmetry** | For symmetric fiber families, $W_{\text{fiber,1}}(\theta) = W_{\text{fiber,2}}(-\theta)$ under symmetric loading |
+| **Macaulay bracket** | Fibers only contribute under tension ($I_4 > 1$) |
+| **NN approach** | Train separate NNs per fiber family, or one NN with all fiber invariants as inputs |
+
+---
+
+## 4. Guccione: Cardiac Tissue
+
+The Guccione model requires **two direction vectors** — fiber direction and sheet direction:
+
+```python
+from hyper_surrogate.mechanics.materials import Guccione
+
+mat = Guccione(
+    parameters={
+        "C": 0.876,       # Overall stiffness (kPa)
+        "bf": 18.48,      # Fiber direction
+        "bt": 3.58,       # Transverse (sheet/normal)
+        "bfs": 1.627,     # Fiber-sheet shear
+        "KBULK": 1000.0,
+    },
+    fiber_direction=np.array([1.0, 0.0, 0.0]),  # f₀
+    sheet_direction=np.array([0.0, 1.0, 0.0]),   # s₀
+)
+# Normal direction n₀ = f₀ × s₀ is computed automatically
+```
+
+### Evaluating Guccione
+
+```python
+# Stretch along fiber direction
+lam = 1.1
+F = np.array([[[lam, 0, 0],
+               [0, 1.0/np.sqrt(lam), 0],
+               [0, 0, 1.0/np.sqrt(lam)]]])
+
+C = Kinematics.right_cauchy_green(F)
+pk2 = mat.evaluate_pk2(C)
+energy = mat.evaluate_energy(C)
+
+print(f"Energy: {energy[0]:.6f}")
+print(f"PK2 S11 (fiber): {pk2[0, 0, 0]:.6f}")
+print(f"PK2 S22 (sheet): {pk2[0, 1, 1]:.6f}")
+print(f"PK2 S33 (normal): {pk2[0, 2, 2]:.6f}")
+```
+
+### Physical interpretation of Guccione parameters
+
+| Parameter | Large value means... |
+|-----------|---------------------|
+| $b_f$ | Stiffer in fiber direction |
+| $b_t$ | Stiffer transversely (sheet & normal) |
+| $b_{fs}$ | Stiffer in fiber-sheet shear |
+
+Typical hierarchy: $b_f > b_t > b_{fs}$ (myocardium is stiffest along fibers).
+
+---
+
+## 5. Anisotropic Data Generation Tips
+
+### 5.1 Fiber-aligned deformations
+
+Ensure your training data covers fiber-relevant deformation states:
+
+```python
+gen = hs.DeformationGenerator(seed=42)
+
+# Combined deformations include rotations that naturally probe fiber directions
+F = gen.combined(n=10000, stretch_range=(0.8, 1.3), shear_range=(-0.2, 0.2))
+```
+
+### 5.2 Check fiber invariant coverage
+
+```python
+C = Kinematics.right_cauchy_green(F)
+i4 = Kinematics.fiber_invariant4(C, fiber_dir)
+
+print(f"I4 range: [{i4.min():.3f}, {i4.max():.3f}]")
+print(f"I4 < 1 (compression): {(i4 < 1).sum()} / {len(i4)}")
+print(f"I4 > 1 (tension): {(i4 > 1).sum()} / {len(i4)}")
+
+# For HolzapfelOgden, fibers only activate under tension (I4 > 1)
+# Ensure sufficient tension samples
+```
+
+### 5.3 Dispersed fiber directions
+
+For materials with fiber dispersion, you can generate varied fiber orientations:
+
+```python
+fibers = gen.fiber_directions(
+    n=100,
+    mean_direction=np.array([1.0, 0.0, 0.0]),
+    dispersion=np.radians(15),  # 15° cone half-angle
+)
+# fibers.shape = (100, 3), all unit vectors
+```
+
+---
+
+## 6. Summary: Anisotropic Model Comparison
+
+| Model | Fiber Families | Directions Needed | Key Feature | Application |
+|-------|:--------------:|:-----------------:|-------------|-------------|
+| **HolzapfelOgden** | 1 | `fiber_direction` | Macaulay bracket (tension-only) | Arterial media |
+| **GOH** | 1 | `fiber_direction` | Dispersion parameter $\kappa$ | Arterial adventitia |
+| **Guccione** | 1 | `fiber_direction` + `sheet_direction` | Fiber-sheet-normal frame | Myocardium |
+| **Two-fiber** | 2 | Two `fiber_direction`s | Combined energy (avoid double-counting) | Full arterial wall |
+
+### NN input dimensions
+
+| Model Type | Input Dim | Components |
+|-----------|:---------:|-----------|
+| Isotropic | 3 | $\bar{I}_1, \bar{I}_2, J$ |
+| Single fiber | 5 | $\bar{I}_1, \bar{I}_2, J, I_4, I_5$ |
+| Two fibers | 7 | $\bar{I}_1, \bar{I}_2, J, I_4^{(1)}, I_5^{(1)}, I_4^{(2)}, I_5^{(2)}$ |

--- a/docs/tutorials/data_generation.md
+++ b/docs/tutorials/data_generation.md
@@ -77,12 +77,12 @@ This is the **recommended mode for training data**: it covers a wide range of de
 
 ### Summary of Deformation Modes
 
-| Mode | Function | Key Parameters | Volume-Preserving |
-|------|----------|---------------|:-----------------:|
-| Uniaxial | `gen.uniaxial()` | `stretch_range` | Yes |
-| Biaxial | `gen.biaxial()` | `stretch_range` | Yes |
-| Shear | `gen.shear()` | `shear_range` | Yes |
-| Combined | `gen.combined()` | `stretch_range`, `shear_range` | Yes |
+| Mode     | Function         | Key Parameters                 | Volume-Preserving |
+| -------- | ---------------- | ------------------------------ | :---------------: |
+| Uniaxial | `gen.uniaxial()` | `stretch_range`                |        Yes        |
+| Biaxial  | `gen.biaxial()`  | `stretch_range`                |        Yes        |
+| Shear    | `gen.shear()`    | `shear_range`                  |        Yes        |
+| Combined | `gen.combined()` | `stretch_range`, `shear_range` |        Yes        |
 
 ---
 
@@ -139,13 +139,13 @@ inputs_aniso = np.column_stack([i1_bar, i2_bar, j, i4, i5])  # (N, 5)
 
 ### Invariant ranges (typical)
 
-| Invariant | Reference Value ($\mathbf{F} = \mathbf{I}$) | Typical Training Range |
-|-----------|:-------------------------------------------:|:---------------------:|
-| $\bar{I}_1$ | 3.0 | 2.5 -- 4.0 |
-| $\bar{I}_2$ | 3.0 | 2.5 -- 4.5 |
-| $J$ | 1.0 | 0.9 -- 1.1 |
-| $I_4$ | 1.0 | 0.5 -- 2.0 |
-| $I_5$ | 1.0 | 0.3 -- 4.0 |
+| Invariant   | Reference Value ($\mathbf{F} = \mathbf{I}$) | Typical Training Range |
+| ----------- | :-----------------------------------------: | :--------------------: |
+| $\bar{I}_1$ |                     3.0                     |       2.5 -- 4.0       |
+| $\bar{I}_2$ |                     3.0                     |       2.5 -- 4.5       |
+| $J$         |                     1.0                     |       0.9 -- 1.1       |
+| $I_4$       |                     1.0                     |       0.5 -- 2.0       |
+| $I_5$       |                     1.0                     |       0.3 -- 4.0       |
 
 ---
 
@@ -173,12 +173,12 @@ cmat = material.evaluate_cmat(C)  # (N, 3, 3, 3, 3)
 
 ### Target types summary
 
-| Target Type | Shape | Use Case |
-|------------|-------|----------|
-| `energy` | `(N,)` | Energy-based training (ICNN, hybrid UMAT) |
-| `dW_dI` | `(N, n_inv)` | Stress gradient (for `EnergyStressLoss`) |
-| PK2 stress | `(N, 3, 3)` | Direct stress prediction |
-| Material tangent | `(N, 3, 3, 3, 3)` | Stress + tangent prediction |
+| Target Type      | Shape             | Use Case                                  |
+| ---------------- | ----------------- | ----------------------------------------- |
+| `energy`         | `(N,)`            | Energy-based training (ICNN, hybrid UMAT) |
+| `dW_dI`          | `(N, n_inv)`      | Stress gradient (for `EnergyStressLoss`)  |
+| PK2 stress       | `(N, 3, 3)`       | Direct stress prediction                  |
+| Material tangent | `(N, 3, 3, 3, 3)` | Stress + tangent prediction               |
 
 ---
 
@@ -207,28 +207,28 @@ print(f"Target shape: {train_ds.targets.shape}")   # (N_train, 6) for pk2_voigt
 
 ### Parameter reference
 
-| Parameter | Options | Default | Description |
-|-----------|---------|---------|-------------|
-| `n_samples` | int | — | Total number of deformation samples |
-| `input_type` | `"invariants"`, `"cauchy_green"` | `"invariants"` | NN input representation |
-| `target_type` | `"energy"`, `"pk2_voigt"`, `"pk2_voigt+cmat_voigt"` | `"pk2_voigt"` | What the NN predicts |
-| `seed` | int | `None` | Random seed for reproducibility |
+| Parameter     | Options                                             | Default        | Description                         |
+| ------------- | --------------------------------------------------- | -------------- | ----------------------------------- |
+| `n_samples`   | int                                                 | —              | Total number of deformation samples |
+| `input_type`  | `"invariants"`, `"cauchy_green"`                    | `"invariants"` | NN input representation             |
+| `target_type` | `"energy"`, `"pk2_voigt"`, `"pk2_voigt+cmat_voigt"` | `"pk2_voigt"`  | What the NN predicts                |
+| `seed`        | int                                                 | `None`         | Random seed for reproducibility     |
 
 ### Input types
 
-| `input_type` | Dimensions | Components |
-|-------------|:----------:|-----------|
-| `"invariants"` (isotropic) | 3 | $\bar{I}_1, \bar{I}_2, J$ |
-| `"invariants"` (anisotropic) | 5 | $\bar{I}_1, \bar{I}_2, J, I_4, I_5$ |
-| `"cauchy_green"` | 6 | $C_{11}, C_{22}, C_{33}, C_{12}, C_{13}, C_{23}$ (Voigt) |
+| `input_type`                 | Dimensions | Components                                               |
+| ---------------------------- | :--------: | -------------------------------------------------------- |
+| `"invariants"` (isotropic)   |     3      | $\bar{I}_1, \bar{I}_2, J$                                |
+| `"invariants"` (anisotropic) |     5      | $\bar{I}_1, \bar{I}_2, J, I_4, I_5$                      |
+| `"cauchy_green"`             |     6      | $C_{11}, C_{22}, C_{33}, C_{12}, C_{13}, C_{23}$ (Voigt) |
 
 ### Target types
 
-| `target_type` | Dimensions | Components |
-|--------------|:----------:|-----------|
-| `"energy"` | 1 | $W$ (+ gradient $\partial W/\partial I$ as auxiliary) |
-| `"pk2_voigt"` | 6 | $S_{11}, S_{22}, S_{33}, S_{12}, S_{13}, S_{23}$ |
-| `"pk2_voigt+cmat_voigt"` | 27 | 6 stress + 21 unique tangent components |
+| `target_type`            | Dimensions | Components                                            |
+| ------------------------ | :--------: | ----------------------------------------------------- |
+| `"energy"`               |     1      | $W$ (+ gradient $\partial W/\partial I$ as auxiliary) |
+| `"pk2_voigt"`            |     6      | $S_{11}, S_{22}, S_{33}, S_{12}, S_{13}, S_{23}$      |
+| `"pk2_voigt+cmat_voigt"` |     27     | 6 stress + 21 unique tangent components               |
 
 ---
 

--- a/docs/tutorials/data_generation.md
+++ b/docs/tutorials/data_generation.md
@@ -1,0 +1,362 @@
+# Data Generation
+
+This tutorial covers the full data generation pipeline: creating synthetic deformation gradients, computing invariants, building normalized datasets, and preparing training data for neural network surrogates.
+
+---
+
+## Overview
+
+The data pipeline consists of three stages:
+
+```
+DeformationGenerator  ──>  Kinematics (invariants)  ──>  create_datasets()
+      (F tensors)           (I1_bar, I2_bar, J, ...)      (train_ds, val_ds)
+```
+
+---
+
+## 1. Deformation Generator
+
+`DeformationGenerator` creates batches of deformation gradient tensors $\mathbf{F}$ representing different loading modes.
+
+```python
+import numpy as np
+from hyper_surrogate.data.deformation import DeformationGenerator
+
+gen = DeformationGenerator(seed=42)  # Reproducible random generation
+```
+
+### 1.1 Uniaxial Tension/Compression
+
+Stretch $\lambda$ along axis 1, with transverse contraction to preserve volume:
+
+$$\mathbf{F} = \begin{bmatrix} \lambda & 0 & 0 \\ 0 & \lambda^{-1/2} & 0 \\ 0 & 0 & \lambda^{-1/2} \end{bmatrix}$$
+
+```python
+F_uni = gen.uniaxial(n=1000, stretch_range=(0.7, 1.5))
+print(f"Shape: {F_uni.shape}")  # (1000, 3, 3)
+
+# Verify incompressibility
+J = np.linalg.det(F_uni)
+print(f"J range: [{J.min():.6f}, {J.max():.6f}]")  # ≈ [1.0, 1.0]
+```
+
+### 1.2 Biaxial Stretch
+
+Independent stretches $\lambda_1, \lambda_2$ along axes 1 and 2:
+
+$$\mathbf{F} = \begin{bmatrix} \lambda_1 & 0 & 0 \\ 0 & \lambda_2 & 0 \\ 0 & 0 & (\lambda_1 \lambda_2)^{-1} \end{bmatrix}$$
+
+```python
+F_bi = gen.biaxial(n=1000, stretch_range=(0.8, 1.3))
+```
+
+### 1.3 Simple Shear
+
+Shear deformation in the 1-2 plane:
+
+$$\mathbf{F} = \begin{bmatrix} 1 & \gamma & 0 \\ 0 & 1 & 0 \\ 0 & 0 & 1 \end{bmatrix}$$
+
+```python
+F_shear = gen.shear(n=1000, shear_range=(-0.3, 0.3))
+```
+
+### 1.4 Combined Deformations
+
+The most realistic mode — combines biaxial stretch, uniaxial stretch, and shear with random rotations:
+
+```python
+F_combined = gen.combined(
+    n=10000,
+    stretch_range=(0.8, 1.3),
+    shear_range=(-0.2, 0.2),
+)
+```
+
+This is the **recommended mode for training data**: it covers a wide range of deformation states and ensures the surrogate generalizes well.
+
+### Summary of Deformation Modes
+
+| Mode | Function | Key Parameters | Volume-Preserving |
+|------|----------|---------------|:-----------------:|
+| Uniaxial | `gen.uniaxial()` | `stretch_range` | Yes |
+| Biaxial | `gen.biaxial()` | `stretch_range` | Yes |
+| Shear | `gen.shear()` | `shear_range` | Yes |
+| Combined | `gen.combined()` | `stretch_range`, `shear_range` | Yes |
+
+---
+
+## 2. Adding Volumetric Perturbation
+
+All basic deformation modes are **incompressible** ($J = 1$). For nearly-incompressible materials (which is what we simulate in FE), you need to add volumetric perturbation so the model learns the volumetric response:
+
+```python
+n = 10000
+F = gen.combined(n, stretch_range=(0.8, 1.3), shear_range=(-0.2, 0.2))
+
+# Perturb volume ratio to J ∈ [0.95, 1.05]
+rng = np.random.default_rng(99)
+J_target = rng.uniform(0.95, 1.05, size=n)
+J_current = np.linalg.det(F)
+F = F * (J_target / J_current)[:, None, None] ** (1.0 / 3.0)
+
+# Verify
+J_new = np.linalg.det(F)
+print(f"J range: [{J_new.min():.4f}, {J_new.max():.4f}]")
+# Output: J range: [0.9500, 1.0500]
+```
+
+The scaling factor $(J_{\text{target}} / J_{\text{current}})^{1/3}$ applies a uniform dilation to each deformation gradient.
+
+---
+
+## 3. Computing Invariants
+
+Once you have deformation gradients, compute the invariants that serve as neural network inputs:
+
+```python
+from hyper_surrogate.mechanics.kinematics import Kinematics
+
+C = Kinematics.right_cauchy_green(F)  # (N, 3, 3)
+
+# Isochoric invariants (3 inputs for isotropic models)
+i1_bar = Kinematics.isochoric_invariant1(C)  # (N,)
+i2_bar = Kinematics.isochoric_invariant2(C)  # (N,)
+j = np.sqrt(Kinematics.det_invariant(C))     # (N,)
+
+inputs_iso = np.column_stack([i1_bar, i2_bar, j])  # (N, 3)
+```
+
+For **anisotropic** materials, add fiber invariants:
+
+```python
+fiber_dir = np.array([1.0, 0.0, 0.0])
+i4 = Kinematics.fiber_invariant4(C, fiber_dir)  # (N,)
+i5 = Kinematics.fiber_invariant5(C, fiber_dir)  # (N,)
+
+inputs_aniso = np.column_stack([i1_bar, i2_bar, j, i4, i5])  # (N, 5)
+```
+
+### Invariant ranges (typical)
+
+| Invariant | Reference Value ($\mathbf{F} = \mathbf{I}$) | Typical Training Range |
+|-----------|:-------------------------------------------:|:---------------------:|
+| $\bar{I}_1$ | 3.0 | 2.5 -- 4.0 |
+| $\bar{I}_2$ | 3.0 | 2.5 -- 4.5 |
+| $J$ | 1.0 | 0.9 -- 1.1 |
+| $I_4$ | 1.0 | 0.5 -- 2.0 |
+| $I_5$ | 1.0 | 0.3 -- 4.0 |
+
+---
+
+## 4. Computing Targets
+
+The material object computes the training targets:
+
+```python
+import hyper_surrogate as hs
+
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+
+# Energy (scalar per sample)
+energy = material.evaluate_energy(C)  # (N,)
+
+# Energy gradient w.r.t. invariants (for thermodynamically consistent training)
+dW_dI = material.evaluate_energy_grad_invariants(C)  # (N, 3) or (N, 5)
+
+# PK2 stress (full tensor)
+pk2 = material.evaluate_pk2(C)  # (N, 3, 3)
+
+# Material tangent
+cmat = material.evaluate_cmat(C)  # (N, 3, 3, 3, 3)
+```
+
+### Target types summary
+
+| Target Type | Shape | Use Case |
+|------------|-------|----------|
+| `energy` | `(N,)` | Energy-based training (ICNN, hybrid UMAT) |
+| `dW_dI` | `(N, n_inv)` | Stress gradient (for `EnergyStressLoss`) |
+| PK2 stress | `(N, 3, 3)` | Direct stress prediction |
+| Material tangent | `(N, 3, 3, 3, 3)` | Stress + tangent prediction |
+
+---
+
+## 5. Using `create_datasets()` (Recommended)
+
+The `create_datasets()` factory function handles the entire pipeline — deformation generation, invariant computation, target evaluation, normalization, and train/val split — in a single call:
+
+```python
+import hyper_surrogate as hs
+
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material,
+    n_samples=10000,
+    input_type="invariants",    # "invariants" or "cauchy_green"
+    target_type="pk2_voigt",    # "energy", "pk2_voigt", or "pk2_voigt+cmat_voigt"
+    seed=42,
+)
+
+print(f"Training samples: {len(train_ds)}")
+print(f"Validation samples: {len(val_ds)}")
+print(f"Input shape: {train_ds.inputs.shape}")    # (N_train, 3)
+print(f"Target shape: {train_ds.targets.shape}")   # (N_train, 6) for pk2_voigt
+```
+
+### Parameter reference
+
+| Parameter | Options | Default | Description |
+|-----------|---------|---------|-------------|
+| `n_samples` | int | — | Total number of deformation samples |
+| `input_type` | `"invariants"`, `"cauchy_green"` | `"invariants"` | NN input representation |
+| `target_type` | `"energy"`, `"pk2_voigt"`, `"pk2_voigt+cmat_voigt"` | `"pk2_voigt"` | What the NN predicts |
+| `seed` | int | `None` | Random seed for reproducibility |
+
+### Input types
+
+| `input_type` | Dimensions | Components |
+|-------------|:----------:|-----------|
+| `"invariants"` (isotropic) | 3 | $\bar{I}_1, \bar{I}_2, J$ |
+| `"invariants"` (anisotropic) | 5 | $\bar{I}_1, \bar{I}_2, J, I_4, I_5$ |
+| `"cauchy_green"` | 6 | $C_{11}, C_{22}, C_{33}, C_{12}, C_{13}, C_{23}$ (Voigt) |
+
+### Target types
+
+| `target_type` | Dimensions | Components |
+|--------------|:----------:|-----------|
+| `"energy"` | 1 | $W$ (+ gradient $\partial W/\partial I$ as auxiliary) |
+| `"pk2_voigt"` | 6 | $S_{11}, S_{22}, S_{33}, S_{12}, S_{13}, S_{23}$ |
+| `"pk2_voigt+cmat_voigt"` | 27 | 6 stress + 21 unique tangent components |
+
+---
+
+## 6. Normalization
+
+All inputs and outputs are standardized (zero-mean, unit-variance) before training. The `Normalizer` stores the transformation parameters for export:
+
+```python
+from hyper_surrogate.data.dataset import Normalizer
+
+# Automatic normalization inside create_datasets()
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(material, n_samples=5000)
+
+# Access normalization parameters
+print(f"Input mean:  {in_norm.params['mean']}")
+print(f"Input std:   {in_norm.params['std']}")
+print(f"Output mean: {out_norm.params['mean']}")
+print(f"Output std:  {out_norm.params['std']}")
+```
+
+### Manual normalization (for custom pipelines)
+
+```python
+norm = Normalizer().fit(raw_data)       # Compute mean & std
+X_normalized = norm.transform(raw_data)  # Apply normalization
+X_original = norm.inverse(X_normalized)  # Reverse normalization
+```
+
+The normalizer parameters are exported alongside the model weights, ensuring consistent inference in the generated Fortran code.
+
+---
+
+## 7. Fiber Directions for Anisotropic Materials
+
+For anisotropic materials, fiber directions can be generated with controlled dispersion:
+
+```python
+gen = DeformationGenerator(seed=42)
+
+# Aligned fibers (no dispersion)
+fibers = gen.fiber_directions(n=100, mean_direction=np.array([1.0, 0.0, 0.0]))
+
+# Dispersed fibers (half-angle cone of 15°)
+fibers_dispersed = gen.fiber_directions(
+    n=100,
+    mean_direction=np.array([1.0, 0.0, 0.0]),
+    dispersion=np.radians(15),
+)
+```
+
+---
+
+## 8. Visualizing Deformation Data
+
+Use the `Reporter` class to inspect your generated deformations:
+
+```python
+from hyper_surrogate.reporting.reporter import Reporter
+
+F = gen.combined(n=5000, stretch_range=(0.8, 1.3))
+C = Kinematics.right_cauchy_green(F)
+
+reporter = Reporter(C)
+
+# Individual plots
+reporter.fig_invariants()           # I1_bar, I2_bar, J histograms
+reporter.fig_principal_stretches()  # λ1, λ2, λ3 distributions
+reporter.fig_volume_change()        # J histogram
+reporter.fig_eigenvalues()          # Eigenvalue spectra of C
+
+# Full PDF report with all figures
+reporter.generate_report("deformation_report/")
+
+# Summary statistics
+stats = reporter.basic_statistics()
+for key, val in stats.items():
+    print(f"{key}: mean={val['mean']:.4f}, std={val['std']:.4f}")
+```
+
+---
+
+## 9. Complete Example: Custom Data Pipeline
+
+When you need full control over the data pipeline (e.g. for hybrid UMAT training):
+
+```python
+import numpy as np
+import hyper_surrogate as hs
+from hyper_surrogate.data.dataset import MaterialDataset, Normalizer
+from hyper_surrogate.data.deformation import DeformationGenerator
+from hyper_surrogate.mechanics.kinematics import Kinematics
+
+# 1. Generate deformations with volumetric perturbation
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+n = 20000
+
+gen = DeformationGenerator(seed=42)
+F = gen.combined(n, stretch_range=(0.8, 1.3), shear_range=(-0.2, 0.2))
+
+rng = np.random.default_rng(99)
+J_target = rng.uniform(0.95, 1.05, size=n)
+F = F * (J_target / np.linalg.det(F))[:, None, None] ** (1.0 / 3.0)
+C = Kinematics.right_cauchy_green(F)
+
+# 2. Compute inputs (invariants)
+i1 = Kinematics.isochoric_invariant1(C)
+i2 = Kinematics.isochoric_invariant2(C)
+j = np.sqrt(Kinematics.det_invariant(C))
+inputs = np.column_stack([i1, i2, j])
+
+# 3. Compute targets (energy + gradient)
+energy = material.evaluate_energy(C)
+dW_dI = material.evaluate_energy_grad_invariants(C)
+
+# 4. Normalize
+in_norm = Normalizer().fit(inputs)
+X = in_norm.transform(inputs).astype(np.float32)
+W = energy.reshape(-1, 1).astype(np.float32)
+S = (dW_dI * in_norm.params["std"]).astype(np.float32)  # Chain rule scaling
+
+# 5. Train/val split
+n_val = int(n * 0.15)
+idx = np.random.default_rng(42).permutation(n)
+train_ds = MaterialDataset(X[idx[n_val:]], (W[idx[n_val:]], S[idx[n_val:]]))
+val_ds = MaterialDataset(X[idx[:n_val]], (W[idx[:n_val]], S[idx[:n_val]]))
+
+print(f"Train: {len(train_ds)}, Val: {len(val_ds)}")
+print(f"Input dim: {X.shape[1]}, Energy range: [{energy.min():.4f}, {energy.max():.4f}]")
+```
+
+This custom pipeline gives you full control and is required for `EnergyStressLoss` training (where the target is a `(W, dW/dI)` tuple).

--- a/docs/tutorials/export_fortran.md
+++ b/docs/tutorials/export_fortran.md
@@ -1,0 +1,390 @@
+# Exporting to Fortran
+
+This tutorial covers the three Fortran export pathways in **hyper-surrogate**: standalone NN modules, hybrid UMAT subroutines (NN energy + analytical mechanics), and purely analytical UMATs from symbolic material models.
+
+---
+
+## Overview: Three Export Paths
+
+| Export Path | Class | What It Generates | NN Required? |
+|------------|-------|-------------------|:------------:|
+| **Standalone NN** | `FortranEmitter` | Fortran 90 module with NN forward pass | Yes |
+| **Hybrid UMAT** | `HybridUMATEmitter` | Complete Abaqus UMAT (NN energy + analytical stress/tangent) | Yes |
+| **Analytical UMAT** | `UMATHandler` | Complete Abaqus UMAT from symbolic material (SymPy CSE) | No |
+
+```
+              ┌─────────────────┐
+              │  Trained Model  │
+              └────────┬────────┘
+                       │
+           ┌───────────┼───────────┐
+           ▼           ▼           ▼
+    FortranEmitter  HybridUMAT  UMATHandler
+     (standalone)   Emitter     (symbolic)
+           │           │           │
+           ▼           ▼           ▼
+      nn_module.f90  umat.f90   umat.f
+```
+
+---
+
+## 1. Weight Extraction: `ExportedModel`
+
+Before any Fortran export, you need to extract the trained model's weights and normalizers into a portable format:
+
+```python
+import hyper_surrogate as hs
+
+# After training...
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+
+# Save to disk (NumPy .npz)
+exported.save("my_model.npz")
+
+# Load later
+exported = hs.ExportedModel.load("my_model.npz")
+```
+
+### What's inside `ExportedModel`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `layers` | `List[LayerInfo]` | Layer metadata (activation, dimensions) |
+| `weights` | `Dict[str, ndarray]` | Weight matrices and bias vectors |
+| `input_normalizer` | `Dict` | Input mean/std for standardization |
+| `output_normalizer` | `Dict` | Output mean/std for de-standardization |
+| `metadata` | `Dict` | Architecture type, input/output dims, branch info |
+
+---
+
+## 2. Standalone Fortran Module (`FortranEmitter`)
+
+Generates a self-contained Fortran 90 module with the NN forward pass. All weights are baked in as `PARAMETER` arrays.
+
+### 2.1 MLP Export
+
+```python
+import hyper_surrogate as hs
+
+# Train an MLP
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material, n_samples=5000,
+    input_type="invariants", target_type="pk2_voigt",
+)
+
+model = hs.MLP(input_dim=3, output_dim=6, hidden_dims=[32, 32], activation="tanh")
+result = hs.Trainer(model, train_ds, val_ds, loss_fn=hs.StressLoss(), max_epochs=500).fit()
+
+# Export
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+emitter = hs.FortranEmitter(exported)
+emitter.write("nn_surrogate.f90")
+```
+
+### 2.2 What the generated Fortran looks like
+
+The `.f90` file contains:
+
+```fortran
+MODULE nn_surrogate
+  IMPLICIT NONE
+  ! ── Normalization parameters ──
+  DOUBLE PRECISION, PARAMETER :: INPUT_MEAN(3) = (/ ... /)
+  DOUBLE PRECISION, PARAMETER :: INPUT_STD(3) = (/ ... /)
+  DOUBLE PRECISION, PARAMETER :: OUTPUT_MEAN(6) = (/ ... /)
+  DOUBLE PRECISION, PARAMETER :: OUTPUT_STD(6) = (/ ... /)
+
+  ! ── Layer weights (15-digit precision) ──
+  DOUBLE PRECISION, PARAMETER :: W1(32, 3) = RESHAPE((/ ... /), (/32, 3/))
+  DOUBLE PRECISION, PARAMETER :: B1(32) = (/ ... /)
+  ! ... more layers ...
+
+CONTAINS
+  SUBROUTINE nn_forward(input, output)
+    DOUBLE PRECISION, INTENT(IN)  :: input(3)
+    DOUBLE PRECISION, INTENT(OUT) :: output(6)
+    DOUBLE PRECISION :: x_norm(3), h1(32), h2(32)
+
+    ! Normalize input
+    x_norm = (input - INPUT_MEAN) / INPUT_STD
+
+    ! Layer 1: MATMUL + tanh
+    h1 = TANH(MATMUL(W1, x_norm) + B1)
+
+    ! Layer 2: MATMUL + tanh
+    h2 = TANH(MATMUL(W2, h1) + B2)
+
+    ! Output layer: MATMUL (no activation)
+    output = MATMUL(W3, h2) + B3
+
+    ! Denormalize output
+    output = output * OUTPUT_STD + OUTPUT_MEAN
+  END SUBROUTINE
+END MODULE
+```
+
+### 2.3 ICNN and PolyconvexICNN Export
+
+The `FortranEmitter` auto-detects the architecture and generates the appropriate forward pass:
+
+```python
+# ICNN export (includes softplus enforcement on z-path weights)
+model = hs.ICNN(input_dim=3, hidden_dims=[32, 32])
+# ... train ...
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+hs.FortranEmitter(exported).write("icnn_energy.f90")
+
+# PolyconvexICNN export (per-branch forward pass)
+model = hs.PolyconvexICNN(groups=[[0], [1], [2]], hidden_dims=[32, 32])
+# ... train ...
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+hs.FortranEmitter(exported).write("polyconvex_energy.f90")
+```
+
+### Key properties of generated Fortran
+
+| Property | Details |
+|----------|---------|
+| **Precision** | 15-digit double precision (`:.15e` format) |
+| **Array layout** | Column-major (native Fortran ordering) |
+| **Forward pass** | `MATMUL`-based (efficient on modern compilers) |
+| **Dependencies** | None — fully self-contained |
+| **Activations** | `TANH`, `softplus` ($\ln(1 + e^x)$), ReLU, sigmoid |
+
+---
+
+## 3. Hybrid UMAT Emitter (`HybridUMATEmitter`)
+
+The most powerful export: generates a **complete Abaqus UMAT subroutine** where:
+
+- The **neural network** provides $W(\bar{I}_1, \bar{I}_2, J)$ (strain energy)
+- **Analytical Fortran code** handles kinematics, stress, tangent, and push-forward
+
+### 3.1 How it works
+
+```
+Abaqus calls UMAT with F (deformation gradient)
+  │
+  ├─ 1. Kinematics:  F → C = F^T·F → I1_bar, I2_bar, J (analytical)
+  │
+  ├─ 2. NN Forward:  [I1_bar, I2_bar, J] → normalize → hidden layers → W (energy)
+  │
+  ├─ 3. NN Backward: Backprop dW/dI1_bar, dW/dI2_bar, dW/dJ
+  │
+  ├─ 4. PK2 Stress:  S = 2·Σ(dW/dI_k)·(dI_k/dC)  (analytical chain rule)
+  │
+  ├─ 5. Hessian:     Forward-mode Jacobian for d²W/dI² (NN second derivatives)
+  │
+  ├─ 6. Tangent:     C_mat from dI/dC and d²W/dI²  (analytical)
+  │
+  ├─ 7. Push-forward: σ = (1/J)·F·S·F^T  (Cauchy stress)
+  │
+  └─ 8. Jaumann:     Spatial tangent + Jaumann rate correction
+```
+
+### 3.2 Example: Isotropic Hybrid UMAT
+
+```python
+import numpy as np
+import hyper_surrogate as hs
+from hyper_surrogate.data.dataset import MaterialDataset, Normalizer
+from hyper_surrogate.data.deformation import DeformationGenerator
+from hyper_surrogate.mechanics.kinematics import Kinematics
+
+# 1. Generate data
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+n = 20000
+gen = DeformationGenerator(seed=42)
+F = gen.combined(n, stretch_range=(0.8, 1.3), shear_range=(-0.2, 0.2))
+rng = np.random.default_rng(99)
+J_target = rng.uniform(0.95, 1.05, size=n)
+F = F * (J_target / np.linalg.det(F))[:, None, None] ** (1.0 / 3.0)
+C = Kinematics.right_cauchy_green(F)
+
+# 2. Invariants and targets
+i1 = Kinematics.isochoric_invariant1(C)
+i2 = Kinematics.isochoric_invariant2(C)
+j = np.sqrt(Kinematics.det_invariant(C))
+inputs = np.column_stack([i1, i2, j])
+energy = material.evaluate_energy(C)
+dW_dI = material.evaluate_energy_grad_invariants(C)
+
+# 3. Normalize and build datasets
+in_norm = Normalizer().fit(inputs)
+X = in_norm.transform(inputs).astype(np.float32)
+W = energy.reshape(-1, 1).astype(np.float32)
+S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+n_val = int(n * 0.15)
+idx = np.random.default_rng(42).permutation(n)
+train_ds = MaterialDataset(X[idx[n_val:]], (W[idx[n_val:]], S[idx[n_val:]]))
+val_ds = MaterialDataset(X[idx[:n_val]], (W[idx[:n_val]], S[idx[:n_val]]))
+
+# 4. Train
+model = hs.MLP(input_dim=3, output_dim=1, hidden_dims=[64, 64, 64], activation="softplus")
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=3000, lr=1e-3, patience=300, batch_size=512,
+).fit()
+
+# 5. Export hybrid UMAT
+energy_norm = Normalizer().fit(energy.reshape(-1, 1))
+exported = hs.extract_weights(result.model, in_norm, energy_norm)
+emitter = hs.HybridUMATEmitter(exported)
+emitter.write("hybrid_umat.f90")
+```
+
+### 3.3 Anisotropic Hybrid UMAT (5D invariants)
+
+When `input_dim=5`, the emitter auto-detects anisotropic mode and generates fiber invariant computation ($I_4, I_5$) plus the corresponding derivatives ($\partial I_4 / \partial \mathbf{C}$, $\partial I_5 / \partial \mathbf{C}$):
+
+```python
+# After training with 5D invariants (I1_bar, I2_bar, J, I4, I5)...
+exported = hs.extract_weights(result.model, in_norm, energy_norm)
+emitter = hs.HybridUMATEmitter(exported)
+emitter.write("hybrid_umat_aniso.f90")
+# Fiber direction is passed via PROPS(1:3) in the Abaqus input file
+```
+
+### 3.4 PolyconvexICNN Hybrid UMAT
+
+```python
+# After training a PolyconvexICNN...
+exported = hs.extract_weights(result.model, in_norm, energy_norm)
+emitter = hs.HybridUMATEmitter(exported)
+emitter.write("hybrid_umat_polyconvex.f90")
+# Block-diagonal Hessian: more efficient tangent computation
+```
+
+### 3.5 What the hybrid UMAT contains
+
+| Section | Description |
+|---------|-------------|
+| **Properties block** | Material parameters from `PROPS` array |
+| **Kinematics** | $\mathbf{F} \to \mathbf{C} \to \bar{I}_1, \bar{I}_2, J$ (+ $I_4, I_5$ for anisotropic) |
+| **NN Forward pass** | Normalized input → hidden layers → $W$ (energy scalar) |
+| **NN Backward pass** | Backpropagation: $\partial W / \partial I_\alpha$ |
+| **Jacobian propagation** | Forward-mode AD: $\partial^2 W / \partial I_\alpha \partial I_\beta$ (Hessian) |
+| **PK2 stress** | $\mathbf{S} = 2 \sum_\alpha (\partial W / \partial I_\alpha)(\partial I_\alpha / \partial \mathbf{C})$ |
+| **Cauchy push-forward** | $\boldsymbol{\sigma} = (1/J)\,\mathbf{F}\,\mathbf{S}\,\mathbf{F}^T$ |
+| **Spatial tangent** | Full 4th-order tensor push-forward + Jaumann rate correction |
+
+---
+
+## 4. Analytical UMAT (`UMATHandler`)
+
+For when you want a Fortran UMAT directly from a symbolic material definition — **no neural network involved**:
+
+```python
+from hyper_surrogate.mechanics.materials import NeoHooke
+from hyper_surrogate.export.fortran.analytical import UMATHandler
+
+material = NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+handler = UMATHandler(material)
+handler.generate("neohooke_umat.f")
+
+print("Generated: neohooke_umat.f")
+```
+
+### How it works
+
+```
+Material (symbolic SEF)
+  │
+  ├─ SymPy: W(C) → S = ∂W/∂C (symbolic differentiation)
+  │
+  ├─ SymPy: S(C) → C_mat = ∂S/∂C (symbolic 2nd derivative)
+  │
+  ├─ SymPy CSE: Common Subexpression Elimination
+  │
+  └─ Fortran code generation: optimized UMAT subroutine
+```
+
+### Features
+
+| Feature | Details |
+|---------|---------|
+| **Exact derivatives** | Symbolic differentiation (no numerical errors) |
+| **CSE optimization** | SymPy identifies and eliminates repeated subexpressions |
+| **Cauchy stress** | Push-forward from PK2 to Cauchy |
+| **Spatial tangent** | Full tangent with Jaumann rate correction |
+| **Compatible** | Works with any symbolic `Material` in the library |
+
+### Works with any material
+
+```python
+from hyper_surrogate.mechanics.materials import MooneyRivlin, Yeoh, Demiray
+
+# Mooney-Rivlin
+mat = MooneyRivlin({"C10": 0.3, "C01": 0.2, "KBULK": 1000.0})
+UMATHandler(mat).generate("mooneyrivlin_umat.f")
+
+# Yeoh
+mat = Yeoh({"C10": 0.5, "C20": -0.01, "C30": 0.001, "KBULK": 1000.0})
+UMATHandler(mat).generate("yeoh_umat.f")
+
+# Demiray
+mat = Demiray({"C1": 0.05, "C2": 8.0, "KBULK": 1000.0})
+UMATHandler(mat).generate("demiray_umat.f")
+```
+
+---
+
+## 5. Choosing an Export Path
+
+| Question | Answer → Export Path |
+|----------|---------------------|
+| Do you need a NN surrogate? | **No** → `UMATHandler` (analytical) |
+| Do you need stress + tangent for FE? | **Yes** → `HybridUMATEmitter` |
+| Do you only need the NN forward pass? | **Yes** → `FortranEmitter` (standalone) |
+| Is the material energy-based (scalar NN)? | **Yes** → `HybridUMATEmitter` |
+| Is the material stress-based (6D NN)? | → `FortranEmitter` + custom UMAT wrapper |
+| Is thermodynamic consistency critical? | **Yes** → `HybridUMATEmitter` with ICNN/PolyconvexICNN |
+
+### Decision flowchart
+
+```
+Need a surrogate?
+├── No  ──────────────> UMATHandler (analytical, symbolic)
+└── Yes
+    └── Need full UMAT (stress + tangent)?
+        ├── No  ──────> FortranEmitter (standalone NN module)
+        └── Yes ──────> HybridUMATEmitter (NN energy + analytical mechanics)
+```
+
+---
+
+## 6. Using the Generated UMAT in Abaqus
+
+### Abaqus input file setup
+
+```
+*MATERIAL, NAME=NN_SURROGATE
+*DEPVAR
+  1,
+*USER MATERIAL, CONSTANTS=2
+** KBULK, (unused)
+  1000.0, 0.0
+```
+
+For anisotropic models, pass the fiber direction via `PROPS`:
+
+```
+*USER MATERIAL, CONSTANTS=5
+** KBULK, fiber_x, fiber_y, fiber_z, (unused)
+  1000.0, 1.0, 0.0, 0.0, 0.0
+```
+
+### Compilation
+
+```bash
+# Compile the UMAT with Abaqus
+abaqus job=my_simulation user=hybrid_umat.f90
+
+# Or with Intel Fortran directly
+ifort -c -O2 hybrid_umat.f90
+```
+
+The generated code uses only standard Fortran 90 features and requires no external libraries.

--- a/docs/tutorials/export_fortran.md
+++ b/docs/tutorials/export_fortran.md
@@ -6,11 +6,11 @@ This tutorial covers the three Fortran export pathways in **hyper-surrogate**: s
 
 ## Overview: Three Export Paths
 
-| Export Path | Class | What It Generates | NN Required? |
-|------------|-------|-------------------|:------------:|
-| **Standalone NN** | `FortranEmitter` | Fortran 90 module with NN forward pass | Yes |
-| **Hybrid UMAT** | `HybridUMATEmitter` | Complete Abaqus UMAT (NN energy + analytical stress/tangent) | Yes |
-| **Analytical UMAT** | `UMATHandler` | Complete Abaqus UMAT from symbolic material (SymPy CSE) | No |
+| Export Path         | Class               | What It Generates                                            | NN Required? |
+| ------------------- | ------------------- | ------------------------------------------------------------ | :----------: |
+| **Standalone NN**   | `FortranEmitter`    | Fortran 90 module with NN forward pass                       |     Yes      |
+| **Hybrid UMAT**     | `HybridUMATEmitter` | Complete Abaqus UMAT (NN energy + analytical stress/tangent) |     Yes      |
+| **Analytical UMAT** | `UMATHandler`       | Complete Abaqus UMAT from symbolic material (SymPy CSE)      |      No      |
 
 ```
               ┌─────────────────┐
@@ -47,13 +47,13 @@ exported = hs.ExportedModel.load("my_model.npz")
 
 ### What's inside `ExportedModel`
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `layers` | `List[LayerInfo]` | Layer metadata (activation, dimensions) |
-| `weights` | `Dict[str, ndarray]` | Weight matrices and bias vectors |
-| `input_normalizer` | `Dict` | Input mean/std for standardization |
-| `output_normalizer` | `Dict` | Output mean/std for de-standardization |
-| `metadata` | `Dict` | Architecture type, input/output dims, branch info |
+| Field               | Type                 | Description                                       |
+| ------------------- | -------------------- | ------------------------------------------------- |
+| `layers`            | `List[LayerInfo]`    | Layer metadata (activation, dimensions)           |
+| `weights`           | `Dict[str, ndarray]` | Weight matrices and bias vectors                  |
+| `input_normalizer`  | `Dict`               | Input mean/std for standardization                |
+| `output_normalizer` | `Dict`               | Output mean/std for de-standardization            |
+| `metadata`          | `Dict`               | Architecture type, input/output dims, branch info |
 
 ---
 
@@ -144,13 +144,13 @@ hs.FortranEmitter(exported).write("polyconvex_energy.f90")
 
 ### Key properties of generated Fortran
 
-| Property | Details |
-|----------|---------|
-| **Precision** | 15-digit double precision (`:.15e` format) |
-| **Array layout** | Column-major (native Fortran ordering) |
-| **Forward pass** | `MATMUL`-based (efficient on modern compilers) |
-| **Dependencies** | None — fully self-contained |
-| **Activations** | `TANH`, `softplus` ($\ln(1 + e^x)$), ReLU, sigmoid |
+| Property         | Details                                            |
+| ---------------- | -------------------------------------------------- |
+| **Precision**    | 15-digit double precision (`:.15e` format)         |
+| **Array layout** | Column-major (native Fortran ordering)             |
+| **Forward pass** | `MATMUL`-based (efficient on modern compilers)     |
+| **Dependencies** | None — fully self-contained                        |
+| **Activations**  | `TANH`, `softplus` ($\ln(1 + e^x)$), ReLU, sigmoid |
 
 ---
 
@@ -260,16 +260,16 @@ emitter.write("hybrid_umat_polyconvex.f90")
 
 ### 3.5 What the hybrid UMAT contains
 
-| Section | Description |
-|---------|-------------|
-| **Properties block** | Material parameters from `PROPS` array |
-| **Kinematics** | $\mathbf{F} \to \mathbf{C} \to \bar{I}_1, \bar{I}_2, J$ (+ $I_4, I_5$ for anisotropic) |
-| **NN Forward pass** | Normalized input → hidden layers → $W$ (energy scalar) |
-| **NN Backward pass** | Backpropagation: $\partial W / \partial I_\alpha$ |
-| **Jacobian propagation** | Forward-mode AD: $\partial^2 W / \partial I_\alpha \partial I_\beta$ (Hessian) |
-| **PK2 stress** | $\mathbf{S} = 2 \sum_\alpha (\partial W / \partial I_\alpha)(\partial I_\alpha / \partial \mathbf{C})$ |
-| **Cauchy push-forward** | $\boldsymbol{\sigma} = (1/J)\,\mathbf{F}\,\mathbf{S}\,\mathbf{F}^T$ |
-| **Spatial tangent** | Full 4th-order tensor push-forward + Jaumann rate correction |
+| Section                  | Description                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ |
+| **Properties block**     | Material parameters from `PROPS` array                                                                 |
+| **Kinematics**           | $\mathbf{F} \to \mathbf{C} \to \bar{I}_1, \bar{I}_2, J$ (+ $I_4, I_5$ for anisotropic)                 |
+| **NN Forward pass**      | Normalized input → hidden layers → $W$ (energy scalar)                                                 |
+| **NN Backward pass**     | Backpropagation: $\partial W / \partial I_\alpha$                                                      |
+| **Jacobian propagation** | Forward-mode AD: $\partial^2 W / \partial I_\alpha \partial I_\beta$ (Hessian)                         |
+| **PK2 stress**           | $\mathbf{S} = 2 \sum_\alpha (\partial W / \partial I_\alpha)(\partial I_\alpha / \partial \mathbf{C})$ |
+| **Cauchy push-forward**  | $\boldsymbol{\sigma} = (1/J)\,\mathbf{F}\,\mathbf{S}\,\mathbf{F}^T$                                    |
+| **Spatial tangent**      | Full 4th-order tensor push-forward + Jaumann rate correction                                           |
 
 ---
 
@@ -304,13 +304,13 @@ Material (symbolic SEF)
 
 ### Features
 
-| Feature | Details |
-|---------|---------|
-| **Exact derivatives** | Symbolic differentiation (no numerical errors) |
-| **CSE optimization** | SymPy identifies and eliminates repeated subexpressions |
-| **Cauchy stress** | Push-forward from PK2 to Cauchy |
-| **Spatial tangent** | Full tangent with Jaumann rate correction |
-| **Compatible** | Works with any symbolic `Material` in the library |
+| Feature               | Details                                                 |
+| --------------------- | ------------------------------------------------------- |
+| **Exact derivatives** | Symbolic differentiation (no numerical errors)          |
+| **CSE optimization**  | SymPy identifies and eliminates repeated subexpressions |
+| **Cauchy stress**     | Push-forward from PK2 to Cauchy                         |
+| **Spatial tangent**   | Full tangent with Jaumann rate correction               |
+| **Compatible**        | Works with any symbolic `Material` in the library       |
 
 ### Works with any material
 
@@ -334,14 +334,14 @@ UMATHandler(mat).generate("demiray_umat.f")
 
 ## 5. Choosing an Export Path
 
-| Question | Answer → Export Path |
-|----------|---------------------|
-| Do you need a NN surrogate? | **No** → `UMATHandler` (analytical) |
-| Do you need stress + tangent for FE? | **Yes** → `HybridUMATEmitter` |
-| Do you only need the NN forward pass? | **Yes** → `FortranEmitter` (standalone) |
-| Is the material energy-based (scalar NN)? | **Yes** → `HybridUMATEmitter` |
-| Is the material stress-based (6D NN)? | → `FortranEmitter` + custom UMAT wrapper |
-| Is thermodynamic consistency critical? | **Yes** → `HybridUMATEmitter` with ICNN/PolyconvexICNN |
+| Question                                  | Answer → Export Path                                   |
+| ----------------------------------------- | ------------------------------------------------------ |
+| Do you need a NN surrogate?               | **No** → `UMATHandler` (analytical)                    |
+| Do you need stress + tangent for FE?      | **Yes** → `HybridUMATEmitter`                          |
+| Do you only need the NN forward pass?     | **Yes** → `FortranEmitter` (standalone)                |
+| Is the material energy-based (scalar NN)? | **Yes** → `HybridUMATEmitter`                          |
+| Is the material stress-based (6D NN)?     | → `FortranEmitter` + custom UMAT wrapper               |
+| Is thermodynamic consistency critical?    | **Yes** → `HybridUMATEmitter` with ICNN/PolyconvexICNN |
 
 ### Decision flowchart
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -1,0 +1,243 @@
+# Getting Started
+
+This tutorial walks you through installing **hyper-surrogate**, creating your first material, computing stress, and understanding the core workflow.
+
+---
+
+## Installation
+
+### Prerequisites
+
+- **Python 3.12+**
+- **uv** (recommended) or pip
+
+### Install with uv (recommended)
+
+```bash
+# Clone the repository
+git clone https://github.com/jpsferreira/hyper-surrogate.git
+cd hyper-surrogate
+
+# Install core dependencies (NumPy, SymPy only — no PyTorch)
+uv sync
+
+# Install with ML support (adds PyTorch)
+uv sync --all-groups --extra ml
+
+# Install pre-commit hooks and dev tools
+make install
+```
+
+### Install with pip
+
+```bash
+pip install hyper-surrogate          # Core only
+pip install hyper-surrogate[ml]      # Core + PyTorch
+```
+
+### Verify installation
+
+```python
+import hyper_surrogate as hs
+print(hs.__version__)
+```
+
+### Dependency overview
+
+| Component | Required Packages | Install Command |
+|-----------|------------------|-----------------|
+| Core (mechanics, data) | `numpy`, `sympy` | `uv sync` |
+| ML (models, training) | `torch` | `uv sync --extra ml` |
+| Visualization | `matplotlib` | Included in core |
+| Parameter fitting | `scipy` | Included in core |
+| Documentation | `mkdocs-material`, `mkdocstrings` | `uv sync --all-groups` |
+
+---
+
+## Your First Material
+
+Every workflow starts by defining a **Material**. The simplest is `NeoHooke`:
+
+```python
+import numpy as np
+import hyper_surrogate as hs
+
+# Create a Neo-Hookean material
+# C10 = half the shear modulus (μ/2)
+# KBULK = bulk modulus (enforces near-incompressibility)
+material = hs.NeoHooke(parameters={"C10": 0.5, "KBULK": 1000.0})
+```
+
+The material object stores:
+
+- The **symbolic strain energy function** $W(\mathbf{C})$
+- Auto-derived **PK2 stress** $\mathbf{S} = 2\,\partial W / \partial \mathbf{C}$
+- Auto-derived **material tangent** $\mathbb{C} = 4\,\partial^2 W / \partial \mathbf{C}^2$
+
+All derivatives are computed symbolically via SymPy — no numerical approximations.
+
+---
+
+## Computing Stress and Energy
+
+### Step 1: Create a deformation
+
+```python
+# A simple uniaxial stretch: λ=1.2 along axis 1
+lam = 1.2
+F = np.array([[[lam, 0, 0],
+               [0, 1.0/np.sqrt(lam), 0],
+               [0, 0, 1.0/np.sqrt(lam)]]])  # shape (1, 3, 3)
+```
+
+### Step 2: Compute the right Cauchy-Green tensor
+
+```python
+C = hs.Kinematics.right_cauchy_green(F)  # C = F^T F, shape (1, 3, 3)
+```
+
+### Step 3: Evaluate stress and energy
+
+```python
+# Second Piola-Kirchhoff stress
+pk2 = material.evaluate_pk2(C)       # shape (1, 3, 3)
+
+# Strain energy density
+energy = material.evaluate_energy(C)  # shape (1,)
+
+# Material tangent (elasticity tensor)
+cmat = material.evaluate_cmat(C)      # shape (1, 3, 3, 3, 3)
+
+print(f"Energy:     {energy[0]:.6f}")
+print(f"PK2 (S11):  {pk2[0, 0, 0]:.6f}")
+print(f"PK2 (S22):  {pk2[0, 1, 1]:.6f}")
+```
+
+### Step 4: Batch evaluation
+
+All operations are vectorized — pass `N` samples at once:
+
+```python
+# Generate 1000 random uniaxial deformations
+gen = hs.DeformationGenerator(seed=42)
+F_batch = gen.uniaxial(n=1000)          # (1000, 3, 3)
+C_batch = hs.Kinematics.right_cauchy_green(F_batch)
+
+pk2_batch = material.evaluate_pk2(C_batch)        # (1000, 3, 3)
+energy_batch = material.evaluate_energy(C_batch)  # (1000,)
+
+print(f"Energy range: [{energy_batch.min():.4f}, {energy_batch.max():.4f}]")
+```
+
+---
+
+## Kinematics Utilities
+
+The `Kinematics` class provides batch-vectorized continuum mechanics operations:
+
+```python
+F = gen.combined(n=500)  # Mixed deformation modes
+
+# Strain tensors
+C = hs.Kinematics.right_cauchy_green(F)  # (500, 3, 3)
+B = hs.Kinematics.left_cauchy_green(F)   # (500, 3, 3)
+
+# Volume ratio
+J = hs.Kinematics.jacobian(F)  # (500,)
+
+# Isochoric invariants
+I1_bar = hs.Kinematics.isochoric_invariant1(C)  # (500,)
+I2_bar = hs.Kinematics.isochoric_invariant2(C)  # (500,)
+
+# Principal stretches (sorted descending)
+stretches = hs.Kinematics.principal_stretches(C)  # (500, 3)
+
+# Fiber invariants (for anisotropic materials)
+a0 = np.array([1.0, 0.0, 0.0])
+I4 = hs.Kinematics.fiber_invariant4(C, a0)  # (500,)
+I5 = hs.Kinematics.fiber_invariant5(C, a0)  # (500,)
+```
+
+**Quick reference table:**
+
+| Method | Input | Output Shape | Description |
+|--------|-------|-------------|-------------|
+| `right_cauchy_green(F)` | `(N,3,3)` | `(N,3,3)` | $\mathbf{C} = \mathbf{F}^T\mathbf{F}$ |
+| `left_cauchy_green(F)` | `(N,3,3)` | `(N,3,3)` | $\mathbf{b} = \mathbf{F}\mathbf{F}^T$ |
+| `jacobian(F)` | `(N,3,3)` | `(N,)` | $J = \det(\mathbf{F})$ |
+| `isochoric_invariant1(C)` | `(N,3,3)` | `(N,)` | $\bar{I}_1 = J^{-2/3} \text{tr}(\mathbf{C})$ |
+| `isochoric_invariant2(C)` | `(N,3,3)` | `(N,)` | $\bar{I}_2 = J^{-4/3} I_2$ |
+| `det_invariant(C)` | `(N,3,3)` | `(N,)` | $I_3 = \det(\mathbf{C}) = J^2$ |
+| `principal_stretches(C)` | `(N,3,3)` | `(N,3)` | $\lambda_1 \ge \lambda_2 \ge \lambda_3$ |
+| `fiber_invariant4(C, a0)` | `(N,3,3)` | `(N,)` | $I_4 = \mathbf{a}_0 \cdot \mathbf{C}\mathbf{a}_0$ |
+| `fiber_invariant5(C, a0)` | `(N,3,3)` | `(N,)` | $I_5 = \mathbf{a}_0 \cdot \mathbf{C}^2\mathbf{a}_0$ |
+
+---
+
+## Available Material Models
+
+Here is every model you can instantiate:
+
+| Model | Import | Invariants | Parameters |
+|-------|--------|-----------|------------|
+| `NeoHooke` | `hs.NeoHooke` | $\bar{I}_1$ | `C10, KBULK` |
+| `MooneyRivlin` | `hs.MooneyRivlin` | $\bar{I}_1, \bar{I}_2$ | `C10, C01, KBULK` |
+| `Yeoh` | `from ...materials import Yeoh` | $\bar{I}_1$ | `C10, C20, C30, KBULK` |
+| `Demiray` | `from ...materials import Demiray` | $\bar{I}_1$ | `C1, C2, KBULK` |
+| `Ogden` | `from ...materials import Ogden` | $\bar{\lambda}_i$ | `mu_p, alpha_p, KBULK` |
+| `Fung` | `from ...materials import Fung` | $\mathbf{E}$ | `c, b1, b2, KBULK` |
+| `HolzapfelOgden` | `hs.HolzapfelOgden` | $\bar{I}_1, I_4$ | `a, b, af, bf, KBULK` |
+| `GasserOgdenHolzapfel` | `from ...materials import GOH` | $\bar{I}_1, I_4$ | `a, b, af, bf, kappa, KBULK` |
+| `Guccione` | `from ...materials import Guccione` | $\mathbf{E}$ (fiber frame) | `C, bf, bt, bfs, KBULK` |
+
+---
+
+## The Big Picture: End-to-End Pipeline
+
+```
+┌──────────┐    ┌────────────────────┐    ┌──────────┐    ┌─────────┐    ┌──────────────┐
+│ Material │───>│ DeformationGenerator│───>│ Dataset  │───>│ Trainer │───>│ FortranEmitter│
+│ (SEF)    │    │ (F, C, invariants) │    │ (X, Y)   │    │ (model) │    │ (.f90 UMAT)  │
+└──────────┘    └────────────────────┘    └──────────┘    └─────────┘    └──────────────┘
+```
+
+Each stage is covered in detail in the following tutorials:
+
+| Tutorial | What You'll Learn |
+|----------|-------------------|
+| [Data Generation](data_generation.md) | Deformation modes, invariants, datasets |
+| [Training Surrogates](training_surrogates.md) | MLP, ICNN, PolyconvexICNN, loss functions |
+| [Fortran Export](export_fortran.md) | Standalone NN, hybrid UMAT, analytical UMAT |
+| [Anisotropic Materials](anisotropic_materials.md) | Fibers, arterial walls, cardiac tissue |
+| [Advanced Topics](advanced_topics.md) | CANN discovery, parameter fitting, benchmarking |
+
+---
+
+## Minimal End-to-End Example
+
+From material definition to Fortran in ~15 lines:
+
+```python
+import hyper_surrogate as hs
+
+# 1. Material
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+
+# 2. Dataset (invariants -> PK2 stress in Voigt notation)
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material, n_samples=5000,
+    input_type="invariants", target_type="pk2_voigt",
+)
+
+# 3. Train
+model = hs.MLP(input_dim=3, output_dim=6, hidden_dims=[32, 32], activation="tanh")
+result = hs.Trainer(model, train_ds, val_ds, loss_fn=hs.StressLoss(), max_epochs=500).fit()
+print(f"Best val loss: {result.history['val_loss'][result.best_epoch]:.6f}")
+
+# 4. Export to Fortran
+exported = hs.extract_weights(result.model, in_norm, out_norm)
+emitter = hs.FortranEmitter(exported)
+emitter.write("nn_surrogate.f90")
+```
+
+The generated `nn_surrogate.f90` is a self-contained Fortran 90 module with all weights baked in as `PARAMETER` arrays — no external dependencies, ready for any FE solver.

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -44,13 +44,13 @@ print(hs.__version__)
 
 ### Dependency overview
 
-| Component | Required Packages | Install Command |
-|-----------|------------------|-----------------|
-| Core (mechanics, data) | `numpy`, `sympy` | `uv sync` |
-| ML (models, training) | `torch` | `uv sync --extra ml` |
-| Visualization | `matplotlib` | Included in core |
-| Parameter fitting | `scipy` | Included in core |
-| Documentation | `mkdocs-material`, `mkdocstrings` | `uv sync --all-groups` |
+| Component              | Required Packages                 | Install Command        |
+| ---------------------- | --------------------------------- | ---------------------- |
+| Core (mechanics, data) | `numpy`, `sympy`                  | `uv sync`              |
+| ML (models, training)  | `torch`                           | `uv sync --extra ml`   |
+| Visualization          | `matplotlib`                      | Included in core       |
+| Parameter fitting      | `scipy`                           | Included in core       |
+| Documentation          | `mkdocs-material`, `mkdocstrings` | `uv sync --all-groups` |
 
 ---
 
@@ -160,17 +160,17 @@ I5 = hs.Kinematics.fiber_invariant5(C, a0)  # (500,)
 
 **Quick reference table:**
 
-| Method | Input | Output Shape | Description |
-|--------|-------|-------------|-------------|
-| `right_cauchy_green(F)` | `(N,3,3)` | `(N,3,3)` | $\mathbf{C} = \mathbf{F}^T\mathbf{F}$ |
-| `left_cauchy_green(F)` | `(N,3,3)` | `(N,3,3)` | $\mathbf{b} = \mathbf{F}\mathbf{F}^T$ |
-| `jacobian(F)` | `(N,3,3)` | `(N,)` | $J = \det(\mathbf{F})$ |
-| `isochoric_invariant1(C)` | `(N,3,3)` | `(N,)` | $\bar{I}_1 = J^{-2/3} \text{tr}(\mathbf{C})$ |
-| `isochoric_invariant2(C)` | `(N,3,3)` | `(N,)` | $\bar{I}_2 = J^{-4/3} I_2$ |
-| `det_invariant(C)` | `(N,3,3)` | `(N,)` | $I_3 = \det(\mathbf{C}) = J^2$ |
-| `principal_stretches(C)` | `(N,3,3)` | `(N,3)` | $\lambda_1 \ge \lambda_2 \ge \lambda_3$ |
-| `fiber_invariant4(C, a0)` | `(N,3,3)` | `(N,)` | $I_4 = \mathbf{a}_0 \cdot \mathbf{C}\mathbf{a}_0$ |
-| `fiber_invariant5(C, a0)` | `(N,3,3)` | `(N,)` | $I_5 = \mathbf{a}_0 \cdot \mathbf{C}^2\mathbf{a}_0$ |
+| Method                    | Input     | Output Shape | Description                                         |
+| ------------------------- | --------- | ------------ | --------------------------------------------------- |
+| `right_cauchy_green(F)`   | `(N,3,3)` | `(N,3,3)`    | $\mathbf{C} = \mathbf{F}^T\mathbf{F}$               |
+| `left_cauchy_green(F)`    | `(N,3,3)` | `(N,3,3)`    | $\mathbf{b} = \mathbf{F}\mathbf{F}^T$               |
+| `jacobian(F)`             | `(N,3,3)` | `(N,)`       | $J = \det(\mathbf{F})$                              |
+| `isochoric_invariant1(C)` | `(N,3,3)` | `(N,)`       | $\bar{I}_1 = J^{-2/3} \text{tr}(\mathbf{C})$        |
+| `isochoric_invariant2(C)` | `(N,3,3)` | `(N,)`       | $\bar{I}_2 = J^{-4/3} I_2$                          |
+| `det_invariant(C)`        | `(N,3,3)` | `(N,)`       | $I_3 = \det(\mathbf{C}) = J^2$                      |
+| `principal_stretches(C)`  | `(N,3,3)` | `(N,3)`      | $\lambda_1 \ge \lambda_2 \ge \lambda_3$             |
+| `fiber_invariant4(C, a0)` | `(N,3,3)` | `(N,)`       | $I_4 = \mathbf{a}_0 \cdot \mathbf{C}\mathbf{a}_0$   |
+| `fiber_invariant5(C, a0)` | `(N,3,3)` | `(N,)`       | $I_5 = \mathbf{a}_0 \cdot \mathbf{C}^2\mathbf{a}_0$ |
 
 ---
 
@@ -178,17 +178,17 @@ I5 = hs.Kinematics.fiber_invariant5(C, a0)  # (500,)
 
 Here is every model you can instantiate:
 
-| Model | Import | Invariants | Parameters |
-|-------|--------|-----------|------------|
-| `NeoHooke` | `hs.NeoHooke` | $\bar{I}_1$ | `C10, KBULK` |
-| `MooneyRivlin` | `hs.MooneyRivlin` | $\bar{I}_1, \bar{I}_2$ | `C10, C01, KBULK` |
-| `Yeoh` | `from ...materials import Yeoh` | $\bar{I}_1$ | `C10, C20, C30, KBULK` |
-| `Demiray` | `from ...materials import Demiray` | $\bar{I}_1$ | `C1, C2, KBULK` |
-| `Ogden` | `from ...materials import Ogden` | $\bar{\lambda}_i$ | `mu_p, alpha_p, KBULK` |
-| `Fung` | `from ...materials import Fung` | $\mathbf{E}$ | `c, b1, b2, KBULK` |
-| `HolzapfelOgden` | `hs.HolzapfelOgden` | $\bar{I}_1, I_4$ | `a, b, af, bf, KBULK` |
-| `GasserOgdenHolzapfel` | `from ...materials import GOH` | $\bar{I}_1, I_4$ | `a, b, af, bf, kappa, KBULK` |
-| `Guccione` | `from ...materials import Guccione` | $\mathbf{E}$ (fiber frame) | `C, bf, bt, bfs, KBULK` |
+| Model                  | Import                              | Invariants                 | Parameters                   |
+| ---------------------- | ----------------------------------- | -------------------------- | ---------------------------- |
+| `NeoHooke`             | `hs.NeoHooke`                       | $\bar{I}_1$                | `C10, KBULK`                 |
+| `MooneyRivlin`         | `hs.MooneyRivlin`                   | $\bar{I}_1, \bar{I}_2$     | `C10, C01, KBULK`            |
+| `Yeoh`                 | `from ...materials import Yeoh`     | $\bar{I}_1$                | `C10, C20, C30, KBULK`       |
+| `Demiray`              | `from ...materials import Demiray`  | $\bar{I}_1$                | `C1, C2, KBULK`              |
+| `Ogden`                | `from ...materials import Ogden`    | $\bar{\lambda}_i$          | `mu_p, alpha_p, KBULK`       |
+| `Fung`                 | `from ...materials import Fung`     | $\mathbf{E}$               | `c, b1, b2, KBULK`           |
+| `HolzapfelOgden`       | `hs.HolzapfelOgden`                 | $\bar{I}_1, I_4$           | `a, b, af, bf, KBULK`        |
+| `GasserOgdenHolzapfel` | `from ...materials import GOH`      | $\bar{I}_1, I_4$           | `a, b, af, bf, kappa, KBULK` |
+| `Guccione`             | `from ...materials import Guccione` | $\mathbf{E}$ (fiber frame) | `C, bf, bt, bfs, KBULK`      |
 
 ---
 
@@ -203,13 +203,13 @@ Here is every model you can instantiate:
 
 Each stage is covered in detail in the following tutorials:
 
-| Tutorial | What You'll Learn |
-|----------|-------------------|
-| [Data Generation](data_generation.md) | Deformation modes, invariants, datasets |
-| [Training Surrogates](training_surrogates.md) | MLP, ICNN, PolyconvexICNN, loss functions |
-| [Fortran Export](export_fortran.md) | Standalone NN, hybrid UMAT, analytical UMAT |
-| [Anisotropic Materials](anisotropic_materials.md) | Fibers, arterial walls, cardiac tissue |
-| [Advanced Topics](advanced_topics.md) | CANN discovery, parameter fitting, benchmarking |
+| Tutorial                                          | What You'll Learn                               |
+| ------------------------------------------------- | ----------------------------------------------- |
+| [Data Generation](data_generation.md)             | Deformation modes, invariants, datasets         |
+| [Training Surrogates](training_surrogates.md)     | MLP, ICNN, PolyconvexICNN, loss functions       |
+| [Fortran Export](export_fortran.md)               | Standalone NN, hybrid UMAT, analytical UMAT     |
+| [Anisotropic Materials](anisotropic_materials.md) | Fibers, arterial walls, cardiac tissue          |
+| [Advanced Topics](advanced_topics.md)             | CANN discovery, parameter fitting, benchmarking |
 
 ---
 

--- a/docs/tutorials/training_surrogates.md
+++ b/docs/tutorials/training_surrogates.md
@@ -18,12 +18,12 @@ Dataset (X, Y)  ──>  Model (MLP / ICNN / PolyconvexICNN / CANN)  ──>  Tr
 
 ### Architecture comparison
 
-| Architecture | Output | Convexity | Physics Guarantee | Input Dim | Output Dim |
-|-------------|--------|:---------:|:-----------------:|:---------:|:----------:|
-| **MLP** | Stress or Energy | None | None | Any | Any |
-| **ICNN** | Energy (scalar) | Convex in inputs | Thermodynamic consistency | Any | 1 |
-| **PolyconvexICNN** | Energy (scalar) | Polyconvex | Stronger thermodynamic guarantee | Any | 1 |
-| **CANN** | Energy (scalar) | Optional | Interpretable + sparse | Any | 1 |
+| Architecture       | Output           |    Convexity     |        Physics Guarantee         | Input Dim | Output Dim |
+| ------------------ | ---------------- | :--------------: | :------------------------------: | :-------: | :--------: |
+| **MLP**            | Stress or Energy |       None       |               None               |    Any    |    Any     |
+| **ICNN**           | Energy (scalar)  | Convex in inputs |    Thermodynamic consistency     |    Any    |     1      |
+| **PolyconvexICNN** | Energy (scalar)  |    Polyconvex    | Stronger thermodynamic guarantee |    Any    |     1      |
+| **CANN**           | Energy (scalar)  |     Optional     |      Interpretable + sparse      |    Any    |     1      |
 
 ### 1.1 MLP (Multi-Layer Perceptron)
 
@@ -48,12 +48,12 @@ Input (3) ──> [Linear 64] ──> tanh ──> [Linear 64] ──> tanh ─�
 
 **Available activations:**
 
-| Activation | Function | Best For |
-|-----------|----------|----------|
-| `"relu"` | $\max(0, x)$ | General use, fast |
-| `"tanh"` | $\tanh(x)$ | Stress prediction (bounded outputs) |
-| `"sigmoid"` | $1/(1 + e^{-x})$ | Bounded [0,1] outputs |
-| `"softplus"` | $\ln(1 + e^x)$ | Energy prediction (smooth, positive) |
+| Activation   | Function         | Best For                             |
+| ------------ | ---------------- | ------------------------------------ |
+| `"relu"`     | $\max(0, x)$     | General use, fast                    |
+| `"tanh"`     | $\tanh(x)$       | Stress prediction (bounded outputs)  |
+| `"sigmoid"`  | $1/(1 + e^{-x})$ | Bounded [0,1] outputs                |
+| `"softplus"` | $\ln(1 + e^x)$   | Energy prediction (smooth, positive) |
 
 **When to use MLP:**
 
@@ -148,11 +148,11 @@ $$W = \sum_{k} \text{softplus}(w_k) \cdot \psi_k(I_\alpha)$$
 
 where $\psi_k$ are basis functions applied per invariant:
 
-| Type | Basis Function $\psi_k$ | Parameters |
-|------|------------------------|------------|
-| Polynomial | $(I_\alpha)^p,\quad p = 1, \ldots, n$ | None (fixed powers) |
-| Exponential | $\exp(b_k I_\alpha^2) - 1$ | Learnable $b_k > 0$ |
-| Logarithmic | $\ln(1 + I_\alpha^2)$ | None |
+| Type        | Basis Function $\psi_k$               | Parameters          |
+| ----------- | ------------------------------------- | ------------------- |
+| Polynomial  | $(I_\alpha)^p,\quad p = 1, \ldots, n$ | None (fixed powers) |
+| Exponential | $\exp(b_k I_\alpha^2) - 1$            | Learnable $b_k > 0$ |
+| Logarithmic | $\ln(1 + I_\alpha^2)$                 | None                |
 
 **Use case:** Model discovery — after training with L1 regularization (`SparseLoss`), inspect which terms survived to identify the minimal constitutive law.
 
@@ -184,10 +184,10 @@ The gradient term is computed via **PyTorch autograd** through the network — t
 loss_fn = hs.EnergyStressLoss(alpha=1.0, beta=1.0)
 ```
 
-| Parameter | Default | Effect |
-|-----------|:-------:|--------|
-| `alpha` | 1.0 | Weight on energy MSE |
-| `beta` | 1.0 | Weight on gradient (stress) MSE |
+| Parameter | Default | Effect                          |
+| --------- | :-----: | ------------------------------- |
+| `alpha`   |   1.0   | Weight on energy MSE            |
+| `beta`    |   1.0   | Weight on gradient (stress) MSE |
 
 **Use with:** ICNN, PolyconvexICNN, MLP (output_dim=1), CANN (`target_type="energy"`).
 
@@ -223,12 +223,12 @@ loss_fn = SparseLoss(alpha=1.0, beta=1.0, l1_lambda=0.01)
 
 ### Loss function decision table
 
-| Scenario | Loss Function | Target Type | Model Output |
-|----------|--------------|-------------|:------------:|
-| Direct stress prediction | `StressLoss` | `pk2_voigt` | 6D |
-| Stress + tangent | `StressTangentLoss` | `pk2_voigt+cmat_voigt` | 27D |
-| Energy-based (thermodynamic) | `EnergyStressLoss` | `energy` | 1D |
-| Model discovery (sparse) | `SparseLoss` | `energy` | 1D |
+| Scenario                     | Loss Function       | Target Type            | Model Output |
+| ---------------------------- | ------------------- | ---------------------- | :----------: |
+| Direct stress prediction     | `StressLoss`        | `pk2_voigt`            |      6D      |
+| Stress + tangent             | `StressTangentLoss` | `pk2_voigt+cmat_voigt` |     27D      |
+| Energy-based (thermodynamic) | `EnergyStressLoss`  | `energy`               |      1D      |
+| Model discovery (sparse)     | `SparseLoss`        | `energy`               |      1D      |
 
 ---
 
@@ -252,26 +252,26 @@ result = hs.Trainer(
 
 ### Trainer parameters
 
-| Parameter | Type | Default | Description |
-|-----------|------|:-------:|-------------|
-| `model` | `SurrogateModel` | — | Network to train |
-| `train_ds` | `MaterialDataset` | — | Training dataset |
-| `val_ds` | `MaterialDataset` | — | Validation dataset |
-| `loss_fn` | Loss | `StressLoss()` | Loss function |
-| `max_epochs` | int | 1000 | Maximum training epochs |
-| `lr` | float | 1e-3 | Initial learning rate (Adam optimizer) |
-| `patience` | int | 100 | Early stopping patience |
-| `batch_size` | int | 256 | Mini-batch size |
-| `device` | str | `"cpu"` | Device (`"cpu"` or `"cuda"`) |
+| Parameter    | Type              |    Default     | Description                            |
+| ------------ | ----------------- | :------------: | -------------------------------------- |
+| `model`      | `SurrogateModel`  |       —        | Network to train                       |
+| `train_ds`   | `MaterialDataset` |       —        | Training dataset                       |
+| `val_ds`     | `MaterialDataset` |       —        | Validation dataset                     |
+| `loss_fn`    | Loss              | `StressLoss()` | Loss function                          |
+| `max_epochs` | int               |      1000      | Maximum training epochs                |
+| `lr`         | float             |      1e-3      | Initial learning rate (Adam optimizer) |
+| `patience`   | int               |      100       | Early stopping patience                |
+| `batch_size` | int               |      256       | Mini-batch size                        |
+| `device`     | str               |    `"cpu"`     | Device (`"cpu"` or `"cuda"`)           |
 
 ### Training features
 
-| Feature | How It Works |
-|---------|-------------|
-| **Early stopping** | Monitors val_loss; stops after `patience` epochs without improvement |
-| **LR scheduling** | `ReduceLROnPlateau`: halves LR when val_loss plateaus |
-| **Best checkpoint** | Saves best model state; restores it after training completes |
-| **Autograd detection** | Automatically enables gradient computation for `EnergyStressLoss` |
+| Feature                | How It Works                                                         |
+| ---------------------- | -------------------------------------------------------------------- |
+| **Early stopping**     | Monitors val_loss; stops after `patience` epochs without improvement |
+| **LR scheduling**      | `ReduceLROnPlateau`: halves LR when val_loss plateaus                |
+| **Best checkpoint**    | Saves best model state; restores it after training completes         |
+| **Autograd detection** | Automatically enables gradient computation for `EnergyStressLoss`    |
 
 ### TrainingResult
 
@@ -497,14 +497,14 @@ for i, name in enumerate(["dW/dI1_bar", "dW/dI2_bar", "dW/dJ"]):
 
 ### Recommended starting configurations
 
-| Scenario | Architecture | Hidden Dims | Activation | Loss | Epochs | LR | Patience |
-|----------|-------------|:-----------:|:----------:|------|:------:|:---:|:--------:|
-| Quick prototype | MLP | `[32, 32]` | `tanh` | `StressLoss` | 500 | 1e-3 | 50 |
-| Production stress | MLP | `[64, 64, 64]` | `tanh` | `StressLoss` | 2000 | 1e-3 | 200 |
-| Convex energy | ICNN | `[32, 32]` | `softplus` | `EnergyStressLoss` | 1000 | 1e-3 | 100 |
-| Polyconvex energy | PolyconvexICNN | `[32, 32]` | `softplus` | `EnergyStressLoss` | 2000 | 1e-3 | 200 |
-| Hybrid UMAT | MLP (out=1) | `[64, 64, 64]` | `softplus` | `EnergyStressLoss` | 3000 | 1e-3 | 300 |
-| Model discovery | CANN | — | — | `SparseLoss` | 500 | 1e-3 | 50 |
+| Scenario          | Architecture   |  Hidden Dims   | Activation | Loss               | Epochs |  LR  | Patience |
+| ----------------- | -------------- | :------------: | :--------: | ------------------ | :----: | :--: | :------: |
+| Quick prototype   | MLP            |   `[32, 32]`   |   `tanh`   | `StressLoss`       |  500   | 1e-3 |    50    |
+| Production stress | MLP            | `[64, 64, 64]` |   `tanh`   | `StressLoss`       |  2000  | 1e-3 |   200    |
+| Convex energy     | ICNN           |   `[32, 32]`   | `softplus` | `EnergyStressLoss` |  1000  | 1e-3 |   100    |
+| Polyconvex energy | PolyconvexICNN |   `[32, 32]`   | `softplus` | `EnergyStressLoss` |  2000  | 1e-3 |   200    |
+| Hybrid UMAT       | MLP (out=1)    | `[64, 64, 64]` | `softplus` | `EnergyStressLoss` |  3000  | 1e-3 |   300    |
+| Model discovery   | CANN           |       —        |     —      | `SparseLoss`       |  500   | 1e-3 |    50    |
 
 ### Tips
 

--- a/docs/tutorials/training_surrogates.md
+++ b/docs/tutorials/training_surrogates.md
@@ -1,0 +1,515 @@
+# Training Neural Network Surrogates
+
+This tutorial covers the neural network architectures available in **hyper-surrogate**, the loss functions for thermodynamically consistent training, and the `Trainer` class with early stopping and learning rate scheduling.
+
+---
+
+## Overview
+
+The surrogate training pipeline:
+
+```
+Dataset (X, Y)  ──>  Model (MLP / ICNN / PolyconvexICNN / CANN)  ──>  Trainer  ──>  TrainingResult
+```
+
+---
+
+## 1. Neural Network Architectures
+
+### Architecture comparison
+
+| Architecture | Output | Convexity | Physics Guarantee | Input Dim | Output Dim |
+|-------------|--------|:---------:|:-----------------:|:---------:|:----------:|
+| **MLP** | Stress or Energy | None | None | Any | Any |
+| **ICNN** | Energy (scalar) | Convex in inputs | Thermodynamic consistency | Any | 1 |
+| **PolyconvexICNN** | Energy (scalar) | Polyconvex | Stronger thermodynamic guarantee | Any | 1 |
+| **CANN** | Energy (scalar) | Optional | Interpretable + sparse | Any | 1 |
+
+### 1.1 MLP (Multi-Layer Perceptron)
+
+The most flexible architecture — a standard feedforward network with no physics constraints:
+
+```python
+import hyper_surrogate as hs
+
+model = hs.MLP(
+    input_dim=3,          # 3 invariants (I1_bar, I2_bar, J)
+    output_dim=6,         # 6 stress components (Voigt)
+    hidden_dims=[64, 64], # Two hidden layers with 64 neurons each
+    activation="tanh",    # Activation function
+)
+```
+
+**Architecture diagram:**
+
+```
+Input (3) ──> [Linear 64] ──> tanh ──> [Linear 64] ──> tanh ──> [Linear 6] ──> Output (6)
+```
+
+**Available activations:**
+
+| Activation | Function | Best For |
+|-----------|----------|----------|
+| `"relu"` | $\max(0, x)$ | General use, fast |
+| `"tanh"` | $\tanh(x)$ | Stress prediction (bounded outputs) |
+| `"sigmoid"` | $1/(1 + e^{-x})$ | Bounded [0,1] outputs |
+| `"softplus"` | $\ln(1 + e^x)$ | Energy prediction (smooth, positive) |
+
+**When to use MLP:**
+
+- Direct stress prediction (output = PK2 Voigt)
+- Quick prototyping without physics constraints
+- When convexity is not required
+
+### 1.2 ICNN (Input-Convex Neural Network)
+
+Guarantees that the output is a **convex function** of the input. This is critical for energy-based training: a convex energy function ensures unique stress states and stable FE simulations.
+
+```python
+model = hs.ICNN(
+    input_dim=3,           # Invariants
+    hidden_dims=[32, 32],  # Hidden layer sizes
+    activation="softplus", # Must be convex activation
+)
+# Output dim is always 1 (scalar energy)
+```
+
+**Architecture (convexity enforced via non-negative z-path weights):**
+
+```
+x ─────────────────────────────────────────────────> Wx₂ ──> + ──> Wx₃ ──> + ──> output
+                                                      |       ↑       |       ↑
+x ──> [Wx₁] ──> σ ──> z₁ ──> [softplus(Wz₂)]·z₁ ──'  σ  [softplus(Wz₃)]·z₂  σ
+                                                            ──> z₂             ──> z₃
+```
+
+Key properties:
+
+- **z-path weights** are passed through `softplus()` to enforce non-negativity
+- **x-path weights** are unconstrained (direct input skip connections)
+- The composition of convex non-decreasing functions with non-negative linear maps preserves convexity
+
+### 1.3 PolyconvexICNN
+
+For **polyconvex** energy functions, each invariant (or group of invariants) gets its own ICNN branch:
+
+```python
+# Isotropic: 3 branches, one per invariant
+model = hs.PolyconvexICNN(
+    groups=[[0], [1], [2]],       # W = W₁(I1_bar) + W₂(I2_bar) + W₃(J)
+    hidden_dims=[32, 32],
+    activation="softplus",
+)
+
+# Anisotropic: 4 branches (fiber invariants grouped)
+model = hs.PolyconvexICNN(
+    groups=[[0], [1], [2], [3, 4]],  # W = W₁(I1) + W₂(I2) + W₃(J) + W₄(I4, I5)
+    hidden_dims=[32, 32],
+    activation="softplus",
+)
+```
+
+**Architecture:**
+
+```
+I1_bar ──> [ICNN branch 1] ──> W₁ ──┐
+I2_bar ──> [ICNN branch 2] ──> W₂ ──┤
+J      ──> [ICNN branch 3] ──> W₃ ──┼──> W = W₁ + W₂ + W₃ (+ W₄)
+I4, I5 ──> [ICNN branch 4] ──> W₄ ──┘
+```
+
+The sum of convex functions is convex, so polyconvexity is guaranteed by construction.
+
+**Advantages over plain ICNN:**
+
+- Block-diagonal Hessian (more efficient tangent computation)
+- Physical interpretability (separate volumetric, isochoric, fiber contributions)
+- Better conditioning
+
+### 1.4 CANN (Constitutive Artificial Neural Network)
+
+An interpretable architecture using predefined basis functions with learnable non-negative weights:
+
+```python
+from hyper_surrogate.models.cann import CANN
+
+model = CANN(
+    input_dim=3,
+    n_polynomial=3,          # (I)^1, (I)^2, (I)^3
+    n_exponential=2,         # exp(b·I²) - 1 (learnable b)
+    use_logarithmic=True,    # log(1 + I²)
+    learnable_exponents=True,
+)
+```
+
+**Energy function:**
+
+$$W = \sum_{k} \text{softplus}(w_k) \cdot \psi_k(I_\alpha)$$
+
+where $\psi_k$ are basis functions applied per invariant:
+
+| Type | Basis Function $\psi_k$ | Parameters |
+|------|------------------------|------------|
+| Polynomial | $(I_\alpha)^p,\quad p = 1, \ldots, n$ | None (fixed powers) |
+| Exponential | $\exp(b_k I_\alpha^2) - 1$ | Learnable $b_k > 0$ |
+| Logarithmic | $\ln(1 + I_\alpha^2)$ | None |
+
+**Use case:** Model discovery — after training with L1 regularization (`SparseLoss`), inspect which terms survived to identify the minimal constitutive law.
+
+---
+
+## 2. Loss Functions
+
+### 2.1 StressLoss
+
+Simple MSE on predicted vs. true stress:
+
+$$\mathcal{L} = \frac{1}{N} \sum_{i=1}^{N} \|\mathbf{S}_{\text{pred}}^{(i)} - \mathbf{S}_{\text{true}}^{(i)}\|^2$$
+
+```python
+loss_fn = hs.StressLoss()
+```
+
+**Use with:** MLP predicting stress directly (`target_type="pk2_voigt"`).
+
+### 2.2 EnergyStressLoss
+
+Joint energy + stress-gradient loss that enforces **thermodynamic consistency**:
+
+$$\mathcal{L} = \alpha \|W_{\text{pred}} - W_{\text{true}}\|^2 + \beta \left\|\frac{\partial W_{\text{pred}}}{\partial \mathbf{x}_{\text{norm}}} - \frac{\partial W_{\text{true}}}{\partial \mathbf{x}_{\text{norm}}}\right\|^2$$
+
+The gradient term is computed via **PyTorch autograd** through the network — this ensures the predicted stress is consistent with the predicted energy.
+
+```python
+loss_fn = hs.EnergyStressLoss(alpha=1.0, beta=1.0)
+```
+
+| Parameter | Default | Effect |
+|-----------|:-------:|--------|
+| `alpha` | 1.0 | Weight on energy MSE |
+| `beta` | 1.0 | Weight on gradient (stress) MSE |
+
+**Use with:** ICNN, PolyconvexICNN, MLP (output_dim=1), CANN (`target_type="energy"`).
+
+**Important:** The dataset target must be a tuple `(W, dW/dx_norm)` — see the [data generation tutorial](data_generation.md#9-complete-example-custom-data-pipeline).
+
+### 2.3 StressTangentLoss
+
+Weighted MSE on both stress and material tangent:
+
+$$\mathcal{L} = \alpha \|\mathbf{S}_{\text{pred}} - \mathbf{S}_{\text{true}}\|^2 + \beta \|\mathbb{C}_{\text{pred}} - \mathbb{C}_{\text{true}}\|^2$$
+
+```python
+from hyper_surrogate.training.losses import StressTangentLoss
+
+loss_fn = StressTangentLoss(alpha=1.0, beta=0.1)
+```
+
+**Use with:** MLP predicting stress + tangent (`target_type="pk2_voigt+cmat_voigt"`, output_dim=27).
+
+### 2.4 SparseLoss
+
+EnergyStressLoss + L1 regularization for model discovery with CANN:
+
+$$\mathcal{L} = \mathcal{L}_{\text{energy+stress}} + \lambda \sum_k |w_k|$$
+
+```python
+from hyper_surrogate.training.losses import SparseLoss
+
+loss_fn = SparseLoss(alpha=1.0, beta=1.0, l1_lambda=0.01)
+```
+
+**Use with:** CANN architecture for identifying minimal constitutive laws.
+
+### Loss function decision table
+
+| Scenario | Loss Function | Target Type | Model Output |
+|----------|--------------|-------------|:------------:|
+| Direct stress prediction | `StressLoss` | `pk2_voigt` | 6D |
+| Stress + tangent | `StressTangentLoss` | `pk2_voigt+cmat_voigt` | 27D |
+| Energy-based (thermodynamic) | `EnergyStressLoss` | `energy` | 1D |
+| Model discovery (sparse) | `SparseLoss` | `energy` | 1D |
+
+---
+
+## 3. The Trainer
+
+The `Trainer` class handles the training loop with early stopping and learning rate scheduling:
+
+```python
+result = hs.Trainer(
+    model,
+    train_ds,
+    val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=2000,
+    lr=1e-3,
+    patience=200,
+    batch_size=512,
+    device="cpu",  # or "cuda"
+).fit()
+```
+
+### Trainer parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|:-------:|-------------|
+| `model` | `SurrogateModel` | — | Network to train |
+| `train_ds` | `MaterialDataset` | — | Training dataset |
+| `val_ds` | `MaterialDataset` | — | Validation dataset |
+| `loss_fn` | Loss | `StressLoss()` | Loss function |
+| `max_epochs` | int | 1000 | Maximum training epochs |
+| `lr` | float | 1e-3 | Initial learning rate (Adam optimizer) |
+| `patience` | int | 100 | Early stopping patience |
+| `batch_size` | int | 256 | Mini-batch size |
+| `device` | str | `"cpu"` | Device (`"cpu"` or `"cuda"`) |
+
+### Training features
+
+| Feature | How It Works |
+|---------|-------------|
+| **Early stopping** | Monitors val_loss; stops after `patience` epochs without improvement |
+| **LR scheduling** | `ReduceLROnPlateau`: halves LR when val_loss plateaus |
+| **Best checkpoint** | Saves best model state; restores it after training completes |
+| **Autograd detection** | Automatically enables gradient computation for `EnergyStressLoss` |
+
+### TrainingResult
+
+```python
+result = trainer.fit()
+
+# Access training history
+result.history["train_loss"]  # List[float] per epoch
+result.history["val_loss"]    # List[float] per epoch
+
+# Best model
+result.model       # The model with best val_loss weights restored
+result.best_epoch  # Epoch index of best val_loss
+
+# Print summary
+best_val = result.history["val_loss"][result.best_epoch]
+print(f"Best val loss: {best_val:.6f} at epoch {result.best_epoch}")
+print(f"Total epochs: {len(result.history['train_loss'])}")
+```
+
+---
+
+## 4. Example: MLP for Direct Stress Prediction
+
+```python
+import hyper_surrogate as hs
+
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+
+# Create dataset: invariants → PK2 Voigt
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material, n_samples=5000,
+    input_type="invariants",
+    target_type="pk2_voigt",
+    seed=42,
+)
+
+# Build model: 3 inputs → 6 outputs
+model = hs.MLP(input_dim=3, output_dim=6, hidden_dims=[64, 64], activation="tanh")
+
+# Train
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.StressLoss(),
+    max_epochs=500,
+    lr=1e-3,
+).fit()
+
+print(f"Best val loss: {result.history['val_loss'][result.best_epoch]:.6f}")
+```
+
+---
+
+## 5. Example: ICNN for Convex Energy Prediction
+
+```python
+import hyper_surrogate as hs
+
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material, n_samples=5000,
+    input_type="invariants",
+    target_type="energy",
+    seed=42,
+)
+
+# ICNN: convex energy output (scalar)
+model = hs.ICNN(input_dim=3, hidden_dims=[32, 32])
+
+# EnergyStressLoss: enforces stress = dW/dI via autograd
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=500,
+).fit()
+
+print(f"Best val loss: {result.history['val_loss'][result.best_epoch]:.6f}")
+```
+
+---
+
+## 6. Example: PolyconvexICNN for Polyconvex Energy
+
+```python
+import hyper_surrogate as hs
+
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+
+train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
+    material, n_samples=5000,
+    input_type="invariants",
+    target_type="energy",
+    seed=42,
+)
+
+# Each invariant gets its own convex branch
+model = hs.PolyconvexICNN(
+    groups=[[0], [1], [2]],  # W = W₁(I1_bar) + W₂(I2_bar) + W₃(J)
+    hidden_dims=[32, 32],
+    activation="softplus",
+)
+
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=2000,
+    lr=1e-3,
+    patience=200,
+).fit()
+
+print(f"Best val loss: {result.history['val_loss'][result.best_epoch]:.6f}")
+```
+
+---
+
+## 7. Example: Energy MLP for Hybrid UMAT
+
+When targeting a hybrid UMAT (NN energy + analytical mechanics), use an MLP with `output_dim=1` and `EnergyStressLoss`:
+
+```python
+import numpy as np
+import hyper_surrogate as hs
+from hyper_surrogate.data.dataset import MaterialDataset, Normalizer
+from hyper_surrogate.data.deformation import DeformationGenerator
+from hyper_surrogate.mechanics.kinematics import Kinematics
+
+# Generate data with volumetric perturbation
+material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+n = 20000
+
+gen = DeformationGenerator(seed=42)
+F = gen.combined(n, stretch_range=(0.8, 1.3), shear_range=(-0.2, 0.2))
+rng = np.random.default_rng(99)
+J_target = rng.uniform(0.95, 1.05, size=n)
+F = F * (J_target / np.linalg.det(F))[:, None, None] ** (1.0 / 3.0)
+C = Kinematics.right_cauchy_green(F)
+
+# Inputs and targets
+i1 = Kinematics.isochoric_invariant1(C)
+i2 = Kinematics.isochoric_invariant2(C)
+j = np.sqrt(Kinematics.det_invariant(C))
+inputs = np.column_stack([i1, i2, j])
+
+energy = material.evaluate_energy(C)
+dW_dI = material.evaluate_energy_grad_invariants(C)
+
+# Normalize
+in_norm = Normalizer().fit(inputs)
+X = in_norm.transform(inputs).astype(np.float32)
+W = energy.reshape(-1, 1).astype(np.float32)
+S = (dW_dI * in_norm.params["std"]).astype(np.float32)
+
+# Split
+n_val = int(n * 0.15)
+idx = np.random.default_rng(42).permutation(n)
+train_ds = MaterialDataset(X[idx[n_val:]], (W[idx[n_val:]], S[idx[n_val:]]))
+val_ds = MaterialDataset(X[idx[:n_val]], (W[idx[:n_val]], S[idx[:n_val]]))
+
+# Train energy MLP
+model = hs.MLP(input_dim=3, output_dim=1, hidden_dims=[64, 64, 64], activation="softplus")
+result = hs.Trainer(
+    model, train_ds, val_ds,
+    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=3000, lr=1e-3, patience=300, batch_size=512,
+).fit()
+
+best_val = result.history["val_loss"][result.best_epoch]
+print(f"Best val loss: {best_val:.6f} (epoch {result.best_epoch})")
+```
+
+---
+
+## 8. Evaluating a Trained Model
+
+### Direct inference
+
+```python
+import torch
+
+model.eval()
+x_test = torch.tensor(val_ds.inputs[:100], dtype=torch.float32)
+
+with torch.no_grad():
+    y_pred = model(x_test).numpy()
+```
+
+### Hybrid inference (energy → stress via autograd)
+
+For energy-based models, compute stress as the gradient of energy:
+
+```python
+model.eval()
+x = torch.tensor(val_ds.inputs[:100], dtype=torch.float32, requires_grad=True)
+
+W_pred = model(x)
+dW_dx = torch.autograd.grad(W_pred.sum(), x, create_graph=True)[0]
+
+# Convert from normalized to raw invariant space
+std_t = torch.tensor(in_norm.params["std"], dtype=torch.float32)
+dW_dI_pred = (dW_dx / std_t).detach().numpy()  # (100, 3)
+```
+
+### Computing R² and MAE
+
+```python
+import numpy as np
+
+# Compare predictions to reference
+dW_dI_ref = dW_dI[idx[:n_val]][:100]
+
+for i, name in enumerate(["dW/dI1_bar", "dW/dI2_bar", "dW/dJ"]):
+    ss_res = np.sum((dW_dI_pred[:, i] - dW_dI_ref[:, i]) ** 2)
+    ss_tot = np.sum((dW_dI_ref[:, i] - dW_dI_ref[:, i].mean()) ** 2)
+    r2 = 1 - ss_res / max(ss_tot, 1e-30)
+    mae = np.mean(np.abs(dW_dI_pred[:, i] - dW_dI_ref[:, i]))
+    print(f"  {name}: R²={r2:.6f}, MAE={mae:.6f}")
+```
+
+---
+
+## 9. Hyperparameter Guidelines
+
+### Recommended starting configurations
+
+| Scenario | Architecture | Hidden Dims | Activation | Loss | Epochs | LR | Patience |
+|----------|-------------|:-----------:|:----------:|------|:------:|:---:|:--------:|
+| Quick prototype | MLP | `[32, 32]` | `tanh` | `StressLoss` | 500 | 1e-3 | 50 |
+| Production stress | MLP | `[64, 64, 64]` | `tanh` | `StressLoss` | 2000 | 1e-3 | 200 |
+| Convex energy | ICNN | `[32, 32]` | `softplus` | `EnergyStressLoss` | 1000 | 1e-3 | 100 |
+| Polyconvex energy | PolyconvexICNN | `[32, 32]` | `softplus` | `EnergyStressLoss` | 2000 | 1e-3 | 200 |
+| Hybrid UMAT | MLP (out=1) | `[64, 64, 64]` | `softplus` | `EnergyStressLoss` | 3000 | 1e-3 | 300 |
+| Model discovery | CANN | — | — | `SparseLoss` | 500 | 1e-3 | 50 |
+
+### Tips
+
+- **Activation**: Use `softplus` for energy models (smooth, positive), `tanh` for stress models
+- **Batch size**: 256--512 works well; larger batches stabilize gradients
+- **Learning rate**: Start at 1e-3; the scheduler will reduce automatically
+- **Data size**: 5000--20000 samples is usually sufficient for 3D invariants
+- **Hidden dimensions**: 32--64 neurons per layer, 2--3 layers is typical

--- a/hyper_surrogate/export/fortran/emitter.py
+++ b/hyper_surrogate/export/fortran/emitter.py
@@ -37,7 +37,7 @@ class FortranEmitter:
         lines = []
         template = self.ACTIVATIONS[activation]
         lines.append(f"  DO i = 1, {size}")
-        lines.append(f"    {var}(i) = {template.format(x=f'{var}(i)')}")
+        lines.append(f"    {var}(i) = {template.format(x=f"{var}(i)")}")
         lines.append("  END DO")
         return lines
 
@@ -284,7 +284,7 @@ class FortranEmitter:
         b_in_dim = len(indices)
         n_hidden = len(branch_layers) - 1
 
-        lines.append(f"    ! === Branch {bi}: inputs [{', '.join(str(i + 1) for i in indices)}] ===")
+        lines.append(f"    ! === Branch {bi}: inputs [{", ".join(str(i + 1) for i in indices)}] ===")
         for si, idx in enumerate(indices):
             lines.append(f"    x_b{bi}({si + 1}) = x_norm({idx + 1})")
         lines.append("")

--- a/hyper_surrogate/export/fortran/hybrid.py
+++ b/hyper_surrogate/export/fortran/hybrid.py
@@ -460,7 +460,7 @@ class HybridUMATEmitter:
             b_in = len(indices)
             n_hidden = len(b_layers) - 1
 
-            lines.append(f"! ---- Branch {bi}: inputs [{', '.join(str(i + 1) for i in indices)}] ----")
+            lines.append(f"! ---- Branch {bi}: inputs [{", ".join(str(i + 1) for i in indices)}] ----")
 
             # Slice input
             for si, idx in enumerate(indices):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,8 +10,17 @@ copyright: Maintained by <a href="https://github.com/jpsferreira">Joao Ferreira<
 nav:
   - Home: index.md
   - Installation: installation.md
-  - Theory: theory.md
+  - Theory:
+    - Overview: theory.md
+    - Constitutive Theory: constitutive_theory.md
   - Materials: materials.md
+  - Tutorials:
+    - Getting Started: tutorials/getting_started.md
+    - Data Generation: tutorials/data_generation.md
+    - Training Surrogates: tutorials/training_surrogates.md
+    - Fortran Export: tutorials/export_fortran.md
+    - Anisotropic Materials: tutorials/anisotropic_materials.md
+    - Advanced Topics: tutorials/advanced_topics.md
   - Examples: examples.md
   - API Reference: modules.md
   - About: about.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,16 +11,16 @@ nav:
   - Home: index.md
   - Installation: installation.md
   - Theory:
-    - Overview: theory.md
-    - Constitutive Theory: constitutive_theory.md
+      - Overview: theory.md
+      - Constitutive Theory: constitutive_theory.md
   - Materials: materials.md
   - Tutorials:
-    - Getting Started: tutorials/getting_started.md
-    - Data Generation: tutorials/data_generation.md
-    - Training Surrogates: tutorials/training_surrogates.md
-    - Fortran Export: tutorials/export_fortran.md
-    - Anisotropic Materials: tutorials/anisotropic_materials.md
-    - Advanced Topics: tutorials/advanced_topics.md
+      - Getting Started: tutorials/getting_started.md
+      - Data Generation: tutorials/data_generation.md
+      - Training Surrogates: tutorials/training_surrogates.md
+      - Fortran Export: tutorials/export_fortran.md
+      - Anisotropic Materials: tutorials/anisotropic_materials.md
+      - Advanced Topics: tutorials/advanced_topics.md
   - Examples: examples.md
   - API Reference: modules.md
   - About: about.md


### PR DESCRIPTION
## Summary

- Add **constitutive theory reference** (`constitutive_theory.md`) with full LaTeX equations for all 9 material models, kinematics, stress measures, chain rule, thermodynamic consistency, and polyconvexity
- Add **6 tutorial pages** covering the complete workflow:
  - **Getting Started**: installation, first material, stress evaluation, kinematics API reference table, minimal end-to-end example
  - **Data Generation**: 4 deformation modes, volumetric perturbation, `create_datasets()` parameter reference, normalization, Reporter diagnostics
  - **Training Surrogates**: MLP/ICNN/PolyconvexICNN/CANN architectures with diagrams; all 4 loss functions with equations; Trainer configuration; 5 worked examples; hyperparameter guidelines
  - **Fortran Export**: 3 export paths (FortranEmitter, HybridUMATEmitter, UMATHandler) with decision flowchart and Abaqus integration instructions
  - **Anisotropic Materials**: HolzapfelOgden, GOH dispersion, two-fiber artery wall, Guccione cardiac tissue with full code examples
  - **Advanced Topics**: CANN model discovery, Treloar parameter fitting, benchmarking suite, deformation reporting, workflow recipes
- Update `mkdocs.yml` navigation with organized Theory and Tutorials sections

## Test plan

- [ ] Verify `make docs` builds without errors
- [ ] Verify `make docs-test` passes
- [ ] Check LaTeX equations render correctly with KaTeX
- [ ] Review code examples match current API

https://claude.ai/code/session_01QFxaXnWZ2RXdwv3yzc7sSj