### PR TITLE
feat: compressible deformation mode + stress-free reference correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `UMATHandler` exported from the package root for symmetric access to all
+  three Fortran emitters (`UMATHandler`, `HybridUMATEmitter`, `FortranEmitter`).
+- Custom-SEF tutorial (`docs/tutorials/custom_materials.md`) and runnable
+  example (`examples/custom_sef.py`) demonstrating how to subclass
+  `Material` with a SymPy `sef` property.
+- Regression tests for the polyconvex Fortran emitter:
+  - Python emulator of the emitted backward pass vs `torch.autograd.functional.grad`.
+  - Emit-string check for the ICNN skip-connection accumulation lines.
+- `CHANGELOG.md` for release-history tracking.
+
+### Fixed
+
+- Polyconvex Fortran emitter no longer drops the ICNN per-layer
+  skip-connection gradient contributions (`wx_l^T · δ_l` for `l ≥ 1`).
+  The omission previously surfaced in Abaqus as a several-MPa spurious
+  hydrostatic Cauchy stress on the volumetric branch.
+
+### Changed
+
+- README and JOSS paper rewritten around the "three paths to a Fortran
+  UMAT" framing — built-in symbolic SEF, custom symbolic SEF, trained
+  surrogate.
+- `mkdocs` navigation updated so the Custom Materials tutorial sits
+  between Getting Started and Data Generation.
+
+## [0.3.0] — 2026
+
+### Added
+
+- Anisotropic material benchmarks: `HolzapfelOgden` and
+  `GasserOgdenHolzapfel` (GOH).
+- LaTeX manuscript scaffold under `paper/manuscript/` with one TeX file
+  per section.
+- Compressible deformation mode (`combined_compressible`) with
+  configurable `j_range` and stress-free-reference correction in the
+  hybrid UMAT emitter.
+- `dW_dI_REF` PARAMETER emitted in the polyconvex Fortran module so
+  the analytical stress is zero at the reference configuration.
+- Test coverage for `PeirlinckArtery` and the `combined_compressible`
+  dataset path.
+- Paper reproduction scripts (`paper/run_benchmarks.py`,
+  `paper/fe_validation.py`, `paper/generate_figures.py`).
+
+### Fixed
+
+- Hybrid emitter no longer triggers `mypy` `no-any-return` errors on
+  the `np.einsum` and `np.log1p` chains.
+
+## [0.2.0]
+
+### Added
+
+- Multi-fiber-family support across the full pipeline (data generator,
+  symbolic mechanics, NN architectures, hybrid emitter).
+- Comprehensive tutorial suite under `docs/tutorials/`.
+- Constitutive theory reference (`docs/constitutive_theory.md`).
+- Benchmarking metrics and an `UMATHandler` test suite.
+
+[Unreleased]: https://github.com/jpsferreira/hyper-surrogate/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jpsferreira/hyper-surrogate/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/jpsferreira/hyper-surrogate/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/jpsferreira/hyper-surrogate/branch/main/graph/badge.svg)](https://codecov.io/gh/jpsferreira/hyper-surrogate)
 [![License](https://img.shields.io/github/license/jpsferreira/hyper-surrogate)](https://img.shields.io/github/license/jpsferreira/hyper-surrogate)
 
-Data-driven surrogates for hyperelastic constitutive models in finite element analysis.
+**Define hyperelastic materials in Python, deploy them in your finite element solver.**
 
 - **Github repository**: <https://github.com/jpsferreira/hyper-surrogate/>
 - **Documentation**: <https://jpsferreira.github.io/hyper-surrogate/>
@@ -22,83 +22,121 @@ Data-driven surrogates for hyperelastic constitutive models in finite element an
 
 ## Why hyper-surrogate?
 
-Finite element solvers need constitutive models (stress-strain relationships) to simulate materials. Writing and maintaining these models — especially user-defined material subroutines (UMATs) for Abaqus/LS-DYNA — is tedious, error-prone, and tightly coupled to the solver.
+Finite element solvers need constitutive models. Writing and maintaining
+those models — especially user-material subroutines for Abaqus, FEAP and
+similar Fortran-based solvers — is repetitive: kinematics, second
+Piola–Kirchhoff stress, consistent tangent, Jaumann correction,
+reference-configuration freedom, all in Fortran 77 or 90.
 
-**hyper-surrogate** provides an end-to-end pipeline that:
+**hyper-surrogate** lets you define your material once in Python and
+emit a self-contained Fortran 90 user subroutine deployable in any
+Fortran-based FE solver. You choose how the material is defined:
 
-1. **Generates training data** from symbolic material definitions (NeoHooke, Mooney-Rivlin, etc.)
-2. **Trains neural network surrogates** (MLP or Input-Convex NN) that learn the strain energy function
-3. **Exports to standalone Fortran 90** with baked-in weights — no Python or external dependencies at runtime
+1. **Built-in symbolic SEF** — one of ten classical isotropic and
+   anisotropic models (Neo-Hooke, Mooney-Rivlin, Yeoh, Holzapfel-Ogden,
+   Gasser-Ogden-Holzapfel, …).
+2. **Custom symbolic SEF** — subclass `Material` with a `sef` property
+   in `SymPy` and the framework derives stress and tangent automatically.
+3. **Data-driven surrogate** — train an MLP, ICNN, or polyconvex ICNN
+   on energy and stress samples from any ground-truth source and emit
+   a hybrid UMAT whose energy is the trained network and whose stress
+   and tangent are computed analytically in Fortran.
 
-This gives you **solver portability** (one training, any Fortran-capable solver), **thermodynamic consistency** (energy-based formulation with automatic stress/tangent derivation), and **speed** (the exported Fortran is a pure forward pass).
+All three paths produce the same artefact: a `.f90` with Cauchy stress,
+analytical consistent tangent, and stress-freedom at the reference
+configuration enforced exactly at emission time. No Python runtime
+is required at solve time.
 
 ## Architecture
 
 ```
-Material ─> DeformationGenerator ─> Dataset ─> MLP / ICNN ─> FortranEmitter ─> .f90
+Material ─> DeformationGenerator ─> Dataset ─> MLP / ICNN ─> HybridUMATEmitter ─> .f90
    │                                              │
    │         (symbolic SEF)                        │  (trained NN weights)
    │                                              │
    └──── UMATHandler ─────────────────────────────┘
-         (analytical Fortran via SymPy CSE)     HybridUMATEmitter
-                                                (NN SEF + analytical mechanics)
+         (analytical Fortran via SymPy CSE)
 ```
 
 ## Features
 
-- **Symbolic mechanics** -- Automatic PK2 stress and stiffness tensor derivation via SymPy
-- **ML surrogates** -- MLP and Input-Convex Neural Network (ICNN) models for constitutive response approximation
-- **Hybrid UMAT** -- NN-based strain energy with analytical kinematics, stress push-forward, and tangent computation
-- **Energy-stress loss** -- Joint energy + stress gradient loss for thermodynamic consistency via autograd
-- **ICNN convexity** -- Input-Convex Neural Networks guarantee convexity of the predicted strain energy
-- **Fortran export** -- Transpile trained models to standalone Fortran 90 subroutines with baked-in weights
-- **Analytical UMAT** -- Generate optimized Fortran UMAT subroutines from symbolic expressions via CSE
+- **Three entry points, one output** — built-in SEF, custom SymPy SEF,
+  or trained surrogate, all emit a structurally identical Fortran UMAT.
+- **Symbolic mechanics** — automatic PK2 stress and stiffness tensor
+  derivation via SymPy; analytical Cauchy push-forward and Jaumann
+  correction emitted with common-subexpression elimination.
+- **NN architectures** — MLP, Input-Convex NN, and polyconvex ICNN,
+  trained with an energy-plus-stress dual loss that backpropagates
+  the gradient target through autograd.
+- **Hybrid UMAT** — neural-network strain energy with closed-form
+  analytical kinematics, stress, and consistent tangent in Fortran;
+  layer-additive Hessian backpropagation verified against autograd
+  at $10^{-5}$ tolerance.
+- **Stress freedom at reference** — enforced exactly at emission time
+  by subtracting a compile-time offset; no surprise residual stress
+  at $\mathbf{C} = \mathbf{I}$.
+- **Anisotropic support** — fiber pseudo-invariants $I_4, I_5$ for one
+  or two fiber families with arbitrary orientations.
 
 ## Quick Start
 
-### MLP surrogate (stress-based)
+Three short pipelines, mirroring the three ways to define a material:
+
+### Path A — built-in symbolic SEF
 
 ```python
-import hyper_surrogate as hs
+from hyper_surrogate import NeoHooke, UMATHandler
 
-# Define material and generate training data
-material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
-train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
-    material, n_samples=5000, input_type="invariants", target_type="pk2_voigt",
-)
-
-# Train an MLP surrogate
-model = hs.MLP(input_dim=3, output_dim=6, hidden_dims=[32, 32], activation="tanh")
-result = hs.Trainer(model, train_ds, val_ds, loss_fn=hs.StressLoss(), max_epochs=500).fit()
-
-# Export to Fortran 90
-exported = hs.extract_weights(result.model, in_norm, out_norm)
-hs.FortranEmitter(exported).write("nn_surrogate.f90")
+UMATHandler(NeoHooke({"C10": 0.5, "KBULK": 1000.0})).generate("neohooke.f90")
 ```
 
-### ICNN surrogate (energy-based)
+### Path B — custom user-defined SEF
 
 ```python
-import hyper_surrogate as hs
+import sympy as sp
+from hyper_surrogate import Material, UMATHandler
 
-material = hs.NeoHooke({"C10": 0.5, "KBULK": 1000.0})
-train_ds, val_ds, in_norm, out_norm = hs.create_datasets(
-    material, n_samples=5000, input_type="invariants", target_type="energy",
-)
+class MyOgdenLike(Material):
+    DEFAULT_PARAMS = {"mu": 1.0, "alpha": 2.0, "KBULK": 1000.0}
 
-# ICNN guarantees convexity of the predicted strain energy
-model = hs.ICNN(input_dim=3, hidden_dims=[32, 32])
-result = hs.Trainer(
-    model, train_ds, val_ds,
-    loss_fn=hs.EnergyStressLoss(alpha=1.0, beta=1.0),
-    max_epochs=500,
-).fit()
+    def __init__(self, parameters=None):
+        super().__init__({**self.DEFAULT_PARAMS, **(parameters or {})})
 
-exported = hs.extract_weights(result.model, in_norm, out_norm)
-exported.save("icnn_surrogate.npz")
+    @property
+    def sef(self):
+        h = self._handler
+        mu, alpha, K = (self._symbols[k] for k in ("mu", "alpha", "KBULK"))
+        return ((mu / alpha) * (h.isochoric_invariant1 ** (alpha / 2) - 3)
+                + 0.5 * K * (sp.sqrt(h.invariant3) - 1) ** 2)
+
+UMATHandler(MyOgdenLike()).generate("mysef.f90")
 ```
 
-See the [examples](https://jpsferreira.github.io/hyper-surrogate/examples/) for more usage patterns, including hybrid UMAT export and analytical Fortran generation.
+### Path C — data-driven surrogate
+
+```python
+from hyper_surrogate import (
+    NeoHooke, MLP, Trainer, EnergyStressLoss,
+    create_datasets, extract_weights, HybridUMATEmitter,
+)
+
+material = NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+train_ds, val_ds, in_norm, energy_norm = create_datasets(
+    material, n_samples=4000, input_type="invariants",
+    target_type="energy", deformation_mode="combined_compressible",
+)
+model = MLP(input_dim=3, output_dim=1, hidden_dims=[64, 64, 64], activation="softplus")
+result = Trainer(model, train_ds, val_ds,
+                 loss_fn=EnergyStressLoss(alpha=1.0, beta=1.0),
+                 max_epochs=2000, patience=200).fit()
+exported = extract_weights(result.model, in_norm, energy_norm)
+HybridUMATEmitter(exported).write("neohooke_hybrid.f90")
+```
+
+See the [documentation](https://jpsferreira.github.io/hyper-surrogate/)
+for the full tutorial set, including [custom materials](https://jpsferreira.github.io/hyper-surrogate/tutorials/custom_materials/),
+[anisotropic models](https://jpsferreira.github.io/hyper-surrogate/tutorials/anisotropic_materials/),
+and the [export-path decision tree](https://jpsferreira.github.io/hyper-surrogate/tutorials/export_fortran/).
 
 ## Installation
 
@@ -119,13 +157,15 @@ uv sync --all-groups --extra ml
 
 Runnable scripts are in the [`examples/`](examples/) directory:
 
-| Script                     | Description                                     |
-| -------------------------- | ----------------------------------------------- |
-| `train_neohooke_sef.py`    | Train MLP on NeoHooke SEF with hybrid inference |
-| `train_neohooke_stress.py` | Train MLP on PK2 stress with `StressLoss`       |
-| `train_icnn_energy.py`     | Train ICNN with `EnergyStressLoss`              |
-| `export_hybrid_umat.py`    | End-to-end train + `HybridUMATEmitter` export   |
-| `analytical_umat.py`       | Symbolic material to Fortran via `UMATHandler`  |
+| Script                     | Path | Description                                             |
+| -------------------------- | ---- | ------------------------------------------------------- |
+| `analytical_umat.py`       | A    | Built-in `NeoHooke` → analytical UMAT via `UMATHandler` |
+| `custom_sef.py`            | B    | Custom Ogden-like SEF → analytical UMAT                 |
+| `export_hybrid_umat.py`    | C    | End-to-end train + `HybridUMATEmitter` export           |
+| `train_neohooke_sef.py`    | C    | Train MLP on NeoHooke SEF with hybrid inference         |
+| `train_icnn_energy.py`     | C    | Train ICNN with `EnergyStressLoss`                      |
+| `train_polyconvex.py`      | C    | Train PolyconvexICNN with per-invariant convexity       |
+| `train_holzapfel_ogden.py` | C    | Anisotropic fiber-reinforced training pipeline          |
 
 Run any example with:
 
@@ -135,4 +175,5 @@ uv run python examples/<script>.py
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and guidelines.
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for
+setup instructions and guidelines.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,4 +5,39 @@
 [![Commit activity](https://img.shields.io/github/commit-activity/m/jpsferreira/hyper-surrogate)](https://img.shields.io/github/commit-activity/m/jpsferreira/hyper-surrogate)
 [![License](https://img.shields.io/github/license/jpsferreira/hyper-surrogate)](https://img.shields.io/github/license/jpsferreira/hyper-surrogate)
 
-Hyperelastic Surrogates
+**Define hyperelastic materials in Python, deploy them in your finite element solver.**
+
+hyper-surrogate turns a hyperelastic material defined in Python into a
+self-contained Fortran 90 user subroutine (UMAT) that links directly to
+commercial and research finite element solvers. A material can be
+defined in three ways:
+
+- **Path A — built-in symbolic SEF.** Pick from ten classical
+  isotropic and anisotropic models and emit a UMAT in one line.
+- **Path B — custom symbolic SEF.** Subclass `Material` with a `sef`
+  property in `SymPy` and the framework derives stress and consistent
+  tangent for you. See the [custom materials tutorial](tutorials/custom_materials.md).
+- **Path C — data-driven surrogate.** Train an MLP, ICNN, or polyconvex
+  ICNN on energy and stress samples from any ground-truth source and
+  emit a hybrid UMAT whose energy is the trained network and whose
+  mechanics is computed analytically in Fortran.
+
+All three paths produce the same artefact — a `.f90` file with Cauchy
+stress, the analytical consistent tangent, and stress-freedom at the
+reference enforced exactly at emission time.
+
+## Where to start
+
+- [Installation](installation.md) — `pip install hyper-surrogate` or `uv sync --extra ml`.
+- [Getting started](tutorials/getting_started.md) — your first material, in five minutes.
+- [Custom materials](tutorials/custom_materials.md) — write your own SEF and get a UMAT.
+- [Fortran export](tutorials/export_fortran.md) — when to pick each of the three emitters.
+- [Examples](examples.md) — runnable scripts for every path.
+
+## Runnable examples for each path
+
+| Path | Example                                                                                                                     | What it does                                                           |
+| ---- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| A    | [`examples/analytical_umat.py`](https://github.com/jpsferreira/hyper-surrogate/blob/main/examples/analytical_umat.py)       | Built-in NeoHooke → analytical Fortran UMAT in one line                |
+| B    | [`examples/custom_sef.py`](https://github.com/jpsferreira/hyper-surrogate/blob/main/examples/custom_sef.py)                 | Custom Ogden-like SEF → analytical Fortran UMAT                        |
+| C    | [`examples/export_hybrid_umat.py`](https://github.com/jpsferreira/hyper-surrogate/blob/main/examples/export_hybrid_umat.py) | Train an MLP and emit a hybrid UMAT (NN energy + analytical mechanics) |

--- a/docs/tutorials/custom_materials.md
+++ b/docs/tutorials/custom_materials.md
@@ -1,0 +1,157 @@
+# Defining your own SEF
+
+When the hyperelastic model you need is not in the built-in catalogue
+but you can write its strain-energy function (SEF) in closed form,
+**hyper-surrogate** lets you plug it into the framework by subclassing
+the `Material` base class. From there, every downstream capability —
+the symbolic Fortran UMAT, the data generator, the surrogate trainer —
+works on your model exactly as it does on `NeoHooke` or
+`HolzapfelOgden`.
+
+This page walks through that workflow end to end.
+
+---
+
+## What `Material` expects from a subclass
+
+A custom material needs three things:
+
+1. A `DEFAULT_PARAMS` class attribute listing every parameter the SEF
+   depends on, with default values.
+2. An `__init__` that merges the user's overrides onto the defaults
+   and calls `super().__init__(params)`.
+3. A `sef` property that returns a single SymPy expression in the
+   standard invariants. The expression is built from the symbolic
+   invariants exposed by `self._handler` and the parameter symbols
+   exposed by `self._symbols`.
+
+That is it. The base class handles symbolic differentiation,
+batch-tensor evaluation, code generation, and integration with the
+data pipeline.
+
+### Invariants exposed by `self._handler`
+
+| Attribute                       | Symbol      | Description                                |
+| ------------------------------- | ----------- | ------------------------------------------ |
+| `_handler.isochoric_invariant1` | $\bar{I}_1$ | First isochoric invariant of $\mathbf{C}$  |
+| `_handler.isochoric_invariant2` | $\bar{I}_2$ | Second isochoric invariant of $\mathbf{C}$ |
+| `_handler.invariant3`           | $I_3 = J^2$ | Determinant of $\mathbf{C}$                |
+
+For anisotropic models with fiber families you also have access to
+$I_4, I_5$ — see [Anisotropic materials](anisotropic_materials.md).
+
+### Parameter symbols via `self._symbols`
+
+Every key you list in `DEFAULT_PARAMS` becomes a SymPy symbol with the
+same name, accessible as `self._symbols["..."]`. Use these inside the
+`sef` expression so that the generated Fortran knows the parameters
+are model inputs (eventually surfaced as the `PROPS` array in the
+emitted UMAT).
+
+---
+
+## Example: a one-term Ogden-like SEF
+
+The SEF
+
+$$
+W(\bar{I}_1, J) = \frac{\mu}{\alpha} \left( \bar{I}_1^{\alpha/2} - 3 \right)
+                + \frac{K}{2} (J - 1)^2
+$$
+
+is not in the built-in catalogue. Here is the full subclass — fewer
+than fifteen lines:
+
+```python
+import sympy as sp
+from hyper_surrogate import Material
+
+class MyOgdenLike(Material):
+    DEFAULT_PARAMS = {"mu": 1.0, "alpha": 2.0, "KBULK": 1000.0}
+
+    def __init__(self, parameters=None):
+        super().__init__({**self.DEFAULT_PARAMS, **(parameters or {})})
+
+    @property
+    def sef(self):
+        h = self._handler
+        mu, alpha, K = (self._symbols[k] for k in ("mu", "alpha", "KBULK"))
+        return (
+            (mu / alpha) * (h.isochoric_invariant1 ** (alpha / 2) - 3)
+            + 0.5 * K * (sp.sqrt(h.invariant3) - 1) ** 2
+        )
+```
+
+Construct it like any built-in material:
+
+```python
+material = MyOgdenLike({"mu": 0.8, "alpha": 3.0, "KBULK": 2000.0})
+```
+
+---
+
+## Going to Fortran in one line
+
+Hand the instance to `UMATHandler` and you get a complete analytical
+Abaqus-compatible UMAT — Cauchy stress, consistent tangent, Jaumann
+correction, all derived symbolically and emitted with common-subexpression
+elimination:
+
+```python
+from hyper_surrogate import UMATHandler
+
+UMATHandler(material).generate("mysef.f90")
+```
+
+No neural network is involved. No Python runtime is needed at solve
+time. The `PARAMETER` arrays inside the emitted `.f90` are determined
+entirely by the symbolic expression in your `sef` property.
+
+A runnable end-to-end version of this example lives at
+[`examples/custom_sef.py`](https://github.com/jpsferreira/hyper-surrogate/blob/main/examples/custom_sef.py).
+
+---
+
+## Driving a surrogate from your custom material
+
+If the SEF is expensive to evaluate (multi-scale, homogenisation, or
+just a heavy SymPy expression), you may prefer to train a neural-network
+surrogate and emit a hybrid UMAT instead. The pipeline is exactly the
+same as for the built-in materials:
+
+```python
+from hyper_surrogate import (
+    MLP, Trainer, EnergyStressLoss,
+    create_datasets, extract_weights, HybridUMATEmitter,
+)
+
+train_ds, val_ds, in_norm, energy_norm = create_datasets(
+    MyOgdenLike(), n_samples=4000,
+    input_type="invariants", target_type="energy",
+    deformation_mode="combined_compressible",
+)
+
+model = MLP(input_dim=3, output_dim=1, hidden_dims=[64, 64, 64], activation="softplus")
+result = Trainer(
+    model, train_ds, val_ds,
+    loss_fn=EnergyStressLoss(alpha=1.0, beta=1.0),
+    max_epochs=2000, patience=200,
+).fit()
+
+exported = extract_weights(result.model, in_norm, energy_norm)
+HybridUMATEmitter(exported).write("mysef_hybrid.f90")
+```
+
+See [Training surrogates](training_surrogates.md) for loss-function
+choices and architecture options, and [Exporting to Fortran](export_fortran.md)
+for the trade-offs between the analytical and hybrid emitters.
+
+---
+
+## Anisotropic and multi-fiber materials
+
+A `Material` subclass with one or more fiber families needs to declare
+the fiber directions and override `sef_from_all_invariants` instead of
+`sef`. See [Anisotropic materials](anisotropic_materials.md) for the
+fiber-aware pattern and the `PeirlinckArtery` source code for a
+worked two-fiber example.

--- a/docs/tutorials/export_fortran.md
+++ b/docs/tutorials/export_fortran.md
@@ -275,7 +275,7 @@ emitter.write("hybrid_umat_polyconvex.f90")
 
 ## 4. Analytical UMAT (`UMATHandler`)
 
-For when you want a Fortran UMAT directly from a symbolic material definition — **no neural network involved**:
+For when you want a Fortran UMAT directly from a symbolic material definition — **no neural network involved**. This is the recommended path whenever the strain-energy function is available in closed form, including custom user-defined SEFs (see [Custom materials](custom_materials.md)).
 
 ```python
 from hyper_surrogate.mechanics.materials import NeoHooke
@@ -346,10 +346,10 @@ UMATHandler(mat).generate("demiray_umat.f")
 ### Decision flowchart
 
 ```
-Need a surrogate?
-├── No  ──────────────> UMATHandler (analytical, symbolic)
-└── Yes
-    └── Need full UMAT (stress + tangent)?
+Is the SEF available in closed form?
+├── Yes ────────────> UMATHandler (analytical, symbolic)
+└── No (data-driven only)
+    └── Need a full UMAT (stress + tangent)?
         ├── No  ──────> FortranEmitter (standalone NN module)
         └── Yes ──────> HybridUMATEmitter (NN energy + analytical mechanics)
 ```

--- a/examples/custom_sef.py
+++ b/examples/custom_sef.py
@@ -1,0 +1,49 @@
+"""Define a custom strain-energy function and emit a Fortran UMAT.
+
+Path B of the hyper-surrogate pipeline: when your hyperelastic model is
+not in the built-in catalogue but you can write it down as a closed-form
+expression in the standard invariants, subclass ``Material`` with a
+``sef`` property and hand the instance to ``UMATHandler`` -- no neural
+network, no training, no Fortran written by hand.
+
+Usage:
+    uv run python examples/custom_sef.py
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import sympy as sp
+
+from hyper_surrogate import Material, UMATHandler
+
+
+class MyOgdenLike(Material):
+    """One-term Ogden-style isochoric SEF plus a quadratic volumetric term.
+
+    W(I1bar, J) = (mu / alpha) * (I1bar^(alpha/2) - 3)  +  (K / 2) * (J - 1)^2
+    """
+
+    DEFAULT_PARAMS: ClassVar[dict[str, float]] = {"mu": 1.0, "alpha": 2.0, "KBULK": 1000.0}
+
+    def __init__(self, parameters: dict[str, float] | None = None) -> None:
+        super().__init__({**self.DEFAULT_PARAMS, **(parameters or {})})
+
+    @property
+    def sef(self) -> sp.Expr:
+        h = self._handler
+        mu, alpha, K = (self._symbols[name] for name in ("mu", "alpha", "KBULK"))
+        return (mu / alpha) * (h.isochoric_invariant1 ** (alpha / 2) - 3) + 0.5 * K * (sp.sqrt(h.invariant3) - 1) ** 2
+
+
+if __name__ == "__main__":
+    print("── 1. Defining custom SEF (MyOgdenLike) ──")
+    material = MyOgdenLike()
+    print(f"  Parameters: {material._params}")
+
+    print("\n── 2. Generating analytical UMAT ──")
+    UMATHandler(material).generate("mysef.f90")
+    print("  Output: mysef.f90")
+    print("\nThis file is a complete Abaqus-compatible UMAT, generated")
+    print("from a single symbolic expression -- no training required.")

--- a/hyper_surrogate/__init__.py
+++ b/hyper_surrogate/__init__.py
@@ -2,6 +2,9 @@
 # Data (always available)
 from hyper_surrogate.data.dataset import MaterialDataset, Normalizer, create_datasets
 from hyper_surrogate.data.deformation import DeformationGenerator
+
+# Symbolic Fortran emitter (no torch required)
+from hyper_surrogate.export.fortran.analytical import UMATHandler
 from hyper_surrogate.mechanics.kinematics import Kinematics
 from hyper_surrogate.mechanics.materials import (
     Demiray,
@@ -60,6 +63,7 @@ __all__ = [
     "Ogden",
     "Reporter",
     "SymbolicHandler",
+    "UMATHandler",
     "Yeoh",
     "create_datasets",
 ]

--- a/hyper_surrogate/data/dataset.py
+++ b/hyper_surrogate/data/dataset.py
@@ -66,21 +66,61 @@ def _pk2_voigt(material: Any, c_batch: np.ndarray) -> np.ndarray:
     ])
 
 
-def create_datasets(
+def create_datasets(  # noqa: C901  -- branchy by design; one branch per supported deformation_mode
     material: Any,
     n_samples: int,
     input_type: Literal["invariants", "cauchy_green"] = "invariants",
     target_type: Literal["energy", "pk2_voigt", "pk2_voigt+cmat_voigt"] = "pk2_voigt",
     val_fraction: float = 0.15,
     seed: int = 42,
+    deformation_mode: Literal["combined", "combined_compressible", "uniaxial", "biaxial", "shear"] = "combined",
+    stretch_range: tuple[float, float] | None = None,
+    shear_range: tuple[float, float] | None = None,
+    j_range: tuple[float, float] | None = None,
 ) -> tuple[MaterialDataset, MaterialDataset, Normalizer, Normalizer]:
-    """Generate data, normalize, split, and wrap in datasets."""
+    """Generate data, normalize, split, and wrap in datasets.
+
+    deformation_mode selects the loading subspace. "uniaxial" mirrors the
+    canonical experimental tensile-test setup and is recommended when a
+    constrained architecture (ICNN, Polyconvex) struggles to fit the full
+    combined deformation space.  "combined_compressible" extends "combined"
+    with a random isotropic dilation so the resulting F has det F ≠ 1,
+    supplying training signal for the J-direction of compressible
+    hyperelastic surrogates.
+    """
     from hyper_surrogate.data.deformation import DeformationGenerator
     from hyper_surrogate.mechanics.kinematics import Kinematics
 
     # Generate deformations
     gen = DeformationGenerator(seed=seed)
-    F = gen.combined(n_samples)
+    sr = stretch_range
+    hr = shear_range
+    jr = j_range
+    if deformation_mode == "uniaxial":
+        F = gen.uniaxial(n_samples) if sr is None else gen.uniaxial(n_samples, stretch_range=sr)
+    elif deformation_mode == "biaxial":
+        F = gen.biaxial(n_samples) if sr is None else gen.biaxial(n_samples, stretch_range=sr)
+    elif deformation_mode == "shear":
+        F = gen.shear(n_samples) if hr is None else gen.shear(n_samples, shear_range=hr)
+    elif deformation_mode == "combined_compressible":
+        kw: dict[str, Any] = {}
+        if sr is not None:
+            kw["stretch_range"] = sr
+        if hr is not None:
+            kw["shear_range"] = hr
+        if jr is not None:
+            kw["j_range"] = jr
+        F = gen.combined_compressible(n_samples, **kw)
+    else:  # "combined"
+        if sr is None and hr is None:
+            F = gen.combined(n_samples)
+        else:
+            kw = {}
+            if sr is not None:
+                kw["stretch_range"] = sr
+            if hr is not None:
+                kw["shear_range"] = hr
+            F = gen.combined(n_samples, **kw)
     C = Kinematics.right_cauchy_green(F)
 
     # Compute inputs

--- a/hyper_surrogate/data/deformation.py
+++ b/hyper_surrogate/data/deformation.py
@@ -111,3 +111,30 @@ class DeformationGenerator:
         fs = self._rotate(fs, r2)
         fb = self._rotate(fb, r3)
         return np.matmul(np.matmul(fb, fu), fs)  # type: ignore[no-any-return]
+
+    def volumetric_dilation(self, n: int, j_range: tuple[float, float] = (0.85, 1.15)) -> np.ndarray:
+        """F = J^(1/3) · I, with J sampled uniformly in `j_range`.
+
+        Used to compose `det F ≠ 1` samples on top of the otherwise
+        volume-preserving primitives in this class.  Default range
+        chosen to bracket the J-drift Abaqus produces at typical
+        near-incompressible bulk moduli with ~10x margin.
+        """
+        j = self._rng.uniform(*j_range, size=n)
+        s = j ** (1.0 / 3.0)
+        return np.einsum("n,ij->nij", s, np.eye(3))
+
+    def combined_compressible(
+        self,
+        n: int,
+        stretch_range: tuple[float, float] = (0.4, 3.0),
+        shear_range: tuple[float, float] = (-1.0, 1.0),
+        j_range: tuple[float, float] = (0.85, 1.15),
+    ) -> np.ndarray:
+        """`combined` post-multiplied by a random isotropic dilation so
+        the resulting F spans a real `det F` range.  Closes the J=1
+        training-data hole that leaves `∂W/∂J` unsupervised when the
+        surrogate is deployed in a compressible FE solve."""
+        F = self.combined(n, stretch_range=stretch_range, shear_range=shear_range)
+        Fv = self.volumetric_dilation(n, j_range=j_range)
+        return np.matmul(Fv, F)  # type: ignore[no-any-return]

--- a/hyper_surrogate/data/deformation.py
+++ b/hyper_surrogate/data/deformation.py
@@ -122,7 +122,7 @@ class DeformationGenerator:
         """
         j = self._rng.uniform(*j_range, size=n)
         s = j ** (1.0 / 3.0)
-        return np.einsum("n,ij->nij", s, np.eye(3))
+        return np.einsum("n,ij->nij", s, np.eye(3))  # type: ignore[no-any-return]
 
     def combined_compressible(
         self,

--- a/hyper_surrogate/export/fortran/hybrid.py
+++ b/hyper_surrogate/export/fortran/hybrid.py
@@ -268,6 +268,10 @@ class HybridUMATEmitter:
 
         # Reference-configuration offset for the polyconvex (sum-of-branches) emitter.
         lines.append("DOUBLE PRECISION, PARAMETER :: W_REF_OFFSET = " + f"{self._W_ref:.15e}".replace("e", "d"))
+        # Reference-configuration gradient: ensures sigma(C=I) = 0 exactly
+        # at deployment.  Mask zeroes out deviatoric invariants whose
+        # dI/dC vanishes at reference anyway (see _compute_reference_gradient).
+        lines.append(self._fmt_1d(self._dW_dI_ref, "dW_dI_REF"))
 
         return "\n".join(lines)
 

--- a/hyper_surrogate/export/fortran/hybrid.py
+++ b/hyper_surrogate/export/fortran/hybrid.py
@@ -678,12 +678,20 @@ class HybridUMATEmitter:
                 lines.append(f"  delta_b{bi}_{li}(ii) = delta_b{bi}_{li}(ii) * dact_b{bi}_{li}(ii)")
                 lines.append("END DO")
 
-            # grad_b = W0^T * delta_0 + wx_final^T
+            # grad_b = wx_final^T + W0^T·delta_0 + sum_l wx_l^T·delta_l   (l = 1..n_hidden-1)
+            # The last term — ICNN per-layer skip connections — was previously omitted
+            # and produced a non-zero residual gradient at the reference, which manifested
+            # in Abaqus as a several-MPa spurious hydrostatic stress on the J branch.
             lines.append(f"DO ii = 1, {b_in}")
             lines.append(f"  grad_b{bi}(ii) = wxf_b{bi}(1, ii)")
             lines.append(f"  DO jj = 1, {hd0}")
             lines.append(f"    grad_b{bi}(ii) = grad_b{bi}(ii) + w_b{bi}_0(jj, ii) * delta_b{bi}_0(jj)")
             lines.append("  END DO")
+            for li in range(1, n_hidden):
+                hd_l = weights[b_layers[li]["weights"]].shape[0]
+                lines.append(f"  DO jj = 1, {hd_l}")
+                lines.append(f"    grad_b{bi}(ii) = grad_b{bi}(ii) + wx_b{bi}_{li}(jj, ii) * delta_b{bi}_{li}(jj)")
+                lines.append("  END DO")
             lines.append("END DO")
             lines.append("")
 

--- a/hyper_surrogate/export/fortran/hybrid.py
+++ b/hyper_surrogate/export/fortran/hybrid.py
@@ -26,7 +26,7 @@ class HybridUMATEmitter:
 
     SUPPORTED_ARCHITECTURES = ("mlp", "polyconvexicnn")
 
-    def __init__(self, exported: ExportedModel) -> None:
+    def __init__(self, exported: ExportedModel, enforce_stress_free_reference: bool = True) -> None:
         arch = exported.metadata.get("architecture")
         if arch not in self.SUPPORTED_ARCHITECTURES:
             msg = f"HybridUMATEmitter supports {self.SUPPORTED_ARCHITECTURES}, got '{arch}'"
@@ -35,6 +35,142 @@ class HybridUMATEmitter:
             msg = "HybridUMATEmitter requires a scalar (output_dim=1) energy model"
             raise ValueError(msg)
         self.exported = exported
+        self.enforce_stress_free_reference = enforce_stress_free_reference
+        if enforce_stress_free_reference:
+            self._W_ref = self._compute_reference_offset()
+            self._dW_dI_ref = self._compute_reference_gradient()
+        else:
+            self._W_ref = 0.0
+            in_dim = self.exported.metadata["input_dim"]
+            self._dW_dI_ref = np.zeros(in_dim)
+
+    # ------------------------------------------------------------------
+    # Reference-configuration offset (Psi(C=I) -> 0 by subtraction)
+    # ------------------------------------------------------------------
+
+    def _reference_input(self) -> tuple[np.ndarray, np.ndarray]:
+        """Reference invariants and their normalized form.
+
+        Returns (x_ref_raw, x_ref_norm).  Raw invariants at C=I:
+        I1_bar=3, I2_bar=3, J=1, and (a0·a0)=1 for any fiber families.
+        """
+        in_dim = self.exported.metadata["input_dim"]
+        x_ref = np.array([3.0, 3.0, 1.0] + [1.0] * (in_dim - 3))
+        in_norm = self.exported.input_normalizer
+        x_norm = x_ref if in_norm is None else (x_ref - in_norm["mean"]) / in_norm["std"]
+        return x_ref, x_norm
+
+    def _compute_reference_offset(self) -> float:
+        """Evaluate the trained network at the reference configuration C=I.
+
+        Subtracting this offset at deployment gives Psi_dep(C=I) = 0 by
+        construction.  Constant; does not affect stress or tangent.
+        """
+        _x_ref, x_norm = self._reference_input()
+        arch = self.exported.metadata.get("architecture")
+        if arch == "polyconvexicnn":
+            return float(self._poly_forward(x_norm))
+        return float(self._mlp_forward(x_norm))
+
+    def _compute_reference_gradient(self) -> np.ndarray:
+        """dW/dI at the reference configuration C=I.
+
+        Only invariants whose dI/dC does NOT vanish at C=I contribute to
+        sigma at the reference; for the standard mechanics inputs that
+        is J (always) and any fiber invariants I4, I5 (when present).
+        The deviatoric invariants I1_bar, I2_bar both have dI/dC = 0 at
+        reference, so their trained dW/dI value never reaches sigma at
+        C=I and is not corrected.
+
+        We compute dW/dI by finite differences on the numpy forward pass
+        (chosen for emitter-portability and robustness across the
+        polyconvex branched architecture).  Tolerance is set by
+        `_FD_EPS`; the result is then passed through 1/in_std to convert
+        from normalized-input gradient to raw-invariant gradient (mirror
+        of what the Fortran does at runtime).
+        """
+        in_dim = self.exported.metadata["input_dim"]
+        _x_ref, x_norm = self._reference_input()
+        arch = self.exported.metadata.get("architecture")
+        forward = self._poly_forward if arch == "polyconvexicnn" else self._mlp_forward
+
+        # Central-difference gradient w.r.t. normalized inputs.
+        eps = 1e-5
+        g_norm = np.zeros(in_dim)
+        for k in range(in_dim):
+            xp = x_norm.copy()
+            xp[k] += eps
+            xm = x_norm.copy()
+            xm[k] -= eps
+            g_norm[k] = (forward(xp) - forward(xm)) / (2.0 * eps)
+
+        # Convert to gradient w.r.t. raw invariants (dW/dI_alpha).
+        in_norm = self.exported.input_normalizer
+        g_raw = g_norm if in_norm is None else g_norm / np.asarray(in_norm["std"])
+
+        # Mask: zero out the components for deviatoric invariants (indices
+        # 0 and 1, corresponding to I1_bar and I2_bar) since their dI/dC
+        # vanishes at reference and the trained gradient there has no
+        # bearing on sigma(C=I).  Keep components for J (index 2) and any
+        # subsequent fiber invariants (indices >= 3).
+        mask = np.ones(in_dim)
+        mask[0] = 0.0  # I1_bar
+        if in_dim >= 2:
+            mask[1] = 0.0  # I2_bar
+        return g_raw * mask
+
+    def _mlp_forward(self, x: np.ndarray) -> float:
+        """Numpy forward pass through an MLP, mirroring the emitted Fortran."""
+        layers = self.exported.layers
+        weights = self.exported.weights
+        h = x
+        for layer in layers:
+            w = weights[layer.weights]
+            b = weights[layer.bias]
+            a = w @ h + b
+            act = layer.activation
+            if act == "softplus":
+                h = np.log1p(np.exp(a))
+            elif act == "tanh":
+                h = np.tanh(a)
+            elif act == "sigmoid":
+                h = 1.0 / (1.0 + np.exp(-a))
+            elif act == "relu":
+                h = np.maximum(0.0, a)
+            else:  # identity
+                h = a
+        return float(h[0])
+
+    def _poly_forward(self, x: np.ndarray) -> float:
+        """Numpy forward pass for the polyconvex (branched-ICNN) emitter."""
+        weights = self.exported.weights
+        branches = self.exported.metadata["branches"]
+
+        def _softplus(w: np.ndarray) -> np.ndarray:
+            return np.log1p(np.exp(w))
+
+        total = 0.0
+        for bi, branch in enumerate(branches):
+            b_layers = branch["layers"]
+            indices = branch["input_indices"]
+            n_hidden = len(b_layers) - 1
+            xb = x[indices]
+            prefix = f"branches.{bi}."
+            # Layer 0
+            W0 = weights[b_layers[0]["weights"]]
+            b0 = weights[b_layers[0]["bias"]]
+            z = np.log1p(np.exp(W0 @ xb + b0))
+            for li in range(1, n_hidden):
+                wz = _softplus(weights[b_layers[li]["weights"]])
+                wx = weights[prefix + f"wx_layers.{li}.weight"]
+                bli = weights[b_layers[li]["bias"]]
+                z = np.log1p(np.exp(wz @ z + wx @ xb + bli))
+            # Output (linear)
+            wz_out = _softplus(weights[b_layers[n_hidden]["weights"]])
+            wxf = weights[prefix + "wx_final.weight"]
+            b_out = weights[b_layers[n_hidden]["bias"]]
+            total += float((wz_out @ z + wxf @ xb + b_out)[0])
+        return total
 
     # ------------------------------------------------------------------
     # Fortran formatting helpers
@@ -43,7 +179,9 @@ class HybridUMATEmitter:
     @staticmethod
     def _fmt_1d(arr: np.ndarray, name: str) -> str:
         n = arr.shape[0]
-        vals = ", &\n    ".join(", ".join(f"{v:.15e}d0" for v in arr[i : i + 4]) for i in range(0, n, 4))
+        vals = ", &\n    ".join(
+            ", ".join(f"{v:.15e}".replace("e", "d") for v in arr[i : i + 4]) for i in range(0, n, 4)
+        )
         return f"DOUBLE PRECISION, PARAMETER :: {name}({n}) = (/ &\n    {vals} /)"
 
     @staticmethod
@@ -51,7 +189,7 @@ class HybridUMATEmitter:
         rows, cols = arr.shape
         # Fortran is column-major
         vals = ", &\n    ".join(
-            ", ".join(f"{v:.15e}d0" for v in arr.T.flat[i : i + 4]) for i in range(0, rows * cols, 4)
+            ", ".join(f"{v:.15e}".replace("e", "d") for v in arr.T.flat[i : i + 4]) for i in range(0, rows * cols, 4)
         )
         return (
             f"DOUBLE PRECISION, PARAMETER :: {name}({rows},{cols}) = RESHAPE((/ &\n    {vals} /), (/ {rows}, {cols} /))"
@@ -83,6 +221,13 @@ class HybridUMATEmitter:
         if self.exported.input_normalizer:
             lines.append(self._fmt_1d(self.exported.input_normalizer["mean"], "in_mean"))
             lines.append(self._fmt_1d(self.exported.input_normalizer["std"], "in_std"))
+
+        # Reference-configuration offset: ensures Psi(C=I) = 0 exactly at deployment.
+        lines.append("DOUBLE PRECISION, PARAMETER :: W_REF_OFFSET = " + f"{self._W_ref:.15e}".replace("e", "d"))
+        # Reference-configuration gradient: ensures sigma(C=I) = 0 exactly
+        # at deployment.  Mask zeroes out deviatoric invariants whose
+        # dI/dC vanishes at reference anyway (see _compute_reference_gradient).
+        lines.append(self._fmt_1d(self._dW_dI_ref, "dW_dI_REF"))
 
         return "\n".join(lines)
 
@@ -120,6 +265,9 @@ class HybridUMATEmitter:
         if self.exported.input_normalizer:
             lines.append(self._fmt_1d(self.exported.input_normalizer["mean"], "in_mean"))
             lines.append(self._fmt_1d(self.exported.input_normalizer["std"], "in_std"))
+
+        # Reference-configuration offset for the polyconvex (sum-of-branches) emitter.
+        lines.append("DOUBLE PRECISION, PARAMETER :: W_REF_OFFSET = " + f"{self._W_ref:.15e}".replace("e", "d"))
 
         return "\n".join(lines)
 
@@ -198,9 +346,9 @@ class HybridUMATEmitter:
                 lines.append(f"d2act{i} = dact{i} * (1.0d0 - 2.0d0 * z{i})")
             lines.append("")
 
-        # W = z_{last}(1) (scalar output)
+        # W = z_{last}(1) (scalar output), shifted to enforce W(C=I)=0 exactly.
         last = n_layers - 1
-        lines.append(f"W_nn = z{last}(1)")
+        lines.append(f"W_nn = z{last}(1) - W_REF_OFFSET")
         lines.append("")
 
         # --- Backward pass: dW/dx_norm ---
@@ -226,10 +374,18 @@ class HybridUMATEmitter:
         lines.append("END DO")
         lines.append("")
 
-        # dW/dI = dW/dx_norm / std (chain rule for normalization)
+        # dW/dI = dW/dx_norm / std (chain rule for normalization).  Then
+        # subtract the reference-configuration dW/dI for those invariants
+        # whose dI/dC does NOT vanish at C=I (J and fiber invariants),
+        # so that sigma(C=I) = 0 exactly.  Components for I1_bar and
+        # I2_bar are left alone (their chain-rule contribution to sigma
+        # at C=I is already zero).
         lines.append("! Convert gradient to raw invariant space: dW/dI = dW/dx_norm / std")
         for k in range(in_dim):
             lines.append(f"dW_dI({k + 1}) = grad_x({k + 1}) / in_std({k + 1})")
+        lines.append("! Subtract reference-configuration dW/dI (stress freedom at C=I)")
+        for k in range(in_dim):
+            lines.append(f"dW_dI({k + 1}) = dW_dI({k + 1}) - dW_dI_REF({k + 1})")
         lines.append("")
 
         # --- Jacobian propagation: P_i = W_i * J_{i-1}, J_i = diag(dact_i) * P_i ---
@@ -589,6 +745,15 @@ class HybridUMATEmitter:
                     )
             lines.append("")
 
+        # Apply reference-configuration offset so Psi(C=I) = 0 exactly,
+        # and subtract dW/dI(ref) for J + fiber invariants so sigma(C=I) = 0.
+        lines.append("W_nn = W_nn - W_REF_OFFSET")
+        in_dim = self.exported.metadata["input_dim"]
+        lines.append("! Subtract reference-configuration dW/dI (stress freedom at C=I)")
+        for k in range(in_dim):
+            lines.append(f"dW_dI({k + 1}) = dW_dI({k + 1}) - dW_dI_REF({k + 1})")
+        lines.append("")
+
         return "\n".join(lines)
 
     @staticmethod
@@ -709,7 +874,8 @@ SUBROUTINE umat(stress, statev, ddsdde, sse, spd, scd, rpl, &
   DOUBLE PRECISION :: dI1_dC(3,3), dI2_dC(3,3), dJ_dC(3,3)
   DOUBLE PRECISION :: eye3(3,3)
   DOUBLE PRECISION :: Jm23, Jm43
-  INTEGER :: ii, jj, kk, ll
+  INTEGER :: ii, jj, kk, ll, mm, nn, pp, qq
+  DOUBLE PRECISION :: val
 {self._emit_aniso_declarations(num_fibers) if aniso else ""}
   ! d²W/dI² from analytical NN Hessian
   DOUBLE PRECISION :: d2W_dI2({n_inv},{n_inv})
@@ -854,7 +1020,6 @@ SUBROUTINE umat(stress, statev, ddsdde, sse, spd, scd, rpl, &
 
   BLOCK
     DOUBLE PRECISION :: dIdC(3, 3, {n_inv})  ! dIdC(:,:,k) = dIk/dC
-    DOUBLE PRECISION :: val
 
     DO ii = 1, 3
       DO jj = 1, 3

--- a/hyper_surrogate/export/fortran/hybrid.py
+++ b/hyper_surrogate/export/fortran/hybrid.py
@@ -147,7 +147,7 @@ class HybridUMATEmitter:
         branches = self.exported.metadata["branches"]
 
         def _softplus(w: np.ndarray) -> np.ndarray:
-            return np.log1p(np.exp(w))
+            return np.log1p(np.exp(w))  # type: ignore[no-any-return]
 
         total = 0.0
         for bi, branch in enumerate(branches):

--- a/hyper_surrogate/mechanics/materials.py
+++ b/hyper_surrogate/mechanics/materials.py
@@ -913,3 +913,137 @@ class HolzapfelOgdenBiaxial(Material):
         param_vals = list(self._params.values())
         results = fn(*inv_vals, *param_vals)
         return np.asarray(results, dtype=float)
+
+
+class PeirlinckArtery(Material):
+    """Discovered arterial SEF from Peirlinck et al. (2024).
+
+    Reference: M. Peirlinck, J. A. Hurtado, M. K. Rausch, A. Buganza Tepole,
+    E. Kuhl, "A universal material model subroutine for soft matter
+    systems", Engineering with Computers (2024). arXiv:2404.13144.
+
+    The "discovered" SEF (their Section 4.3) for thoracic aortic tissue
+    fitted to 5-protocol biaxial data (Niestrawska 2016, Niestrawska 2018):
+
+        W = (mu1 / 2) * (I1_bar - 3)
+          + (a / 2b) * (exp(b * (I1_bar - 3)) - 1)
+          + sum_{k=1,2} (mu5 / 2) * (I5_k - 1)^2
+
+    Two fiber families at angles +- alpha against the circumferential
+    direction. Default parameters: media layer of the human aortic arch,
+    alpha = 7.0 deg, (mu1, a, b, mu5) = (33.45, 3.74, 6.66, 2.17) kPa.
+
+    Parameter sets reported in the paper (kPa, deg):
+        media:      mu1=33.45, a=3.74, b=6.66,  mu5=2.17, alpha=+-7.00
+        adventitia: mu1=8.30,  a=1.42, b=6.34,  mu5=0.49, alpha=+-66.78
+    """
+
+    DEFAULT_PARAMS: ClassVar[dict[str, float]] = {
+        "mu1": 33.45,
+        "a": 3.74,
+        "b": 6.66,
+        "mu5": 2.17,
+        "KBULK": 1000.0,
+    }
+
+    @classmethod
+    def media(cls) -> PeirlinckArtery:
+        return cls(
+            parameters={"mu1": 33.45, "a": 3.74, "b": 6.66, "mu5": 2.17, "KBULK": 1000.0},
+            fiber_angle_deg=7.0,
+        )
+
+    @classmethod
+    def adventitia(cls) -> PeirlinckArtery:
+        return cls(
+            parameters={"mu1": 8.30, "a": 1.42, "b": 6.34, "mu5": 0.49, "KBULK": 1000.0},
+            fiber_angle_deg=66.78,
+        )
+
+    def __init__(
+        self,
+        parameters: dict[str, float] | None = None,
+        fiber_directions: list[np.ndarray] | None = None,
+        fiber_angle_deg: float | None = None,
+    ) -> None:
+        params = {**self.DEFAULT_PARAMS, **(parameters or {})}
+        if fiber_directions is None:
+            theta = np.radians(7.0 if fiber_angle_deg is None else fiber_angle_deg)
+            fiber_directions = [
+                np.array([np.cos(theta), np.sin(theta), 0.0]),
+                np.array([np.cos(theta), -np.sin(theta), 0.0]),
+            ]
+        if len(fiber_directions) != 2:
+            msg = f"PeirlinckArtery requires exactly 2 fiber directions, got {len(fiber_directions)}"
+            raise ValueError(msg)
+        super().__init__(params, fiber_directions=fiber_directions)
+
+    def _volumetric(self, j: Symbol) -> Expr:
+        KBULK = self._symbols["KBULK"]
+        i3 = j**2
+        return Rational(1, 4) * KBULK * (i3 - 1 - 2 * log(i3 ** Rational(1, 2)))
+
+    @property
+    def sef(self) -> Expr:
+        msg = "PeirlinckArtery.sef requires fiber invariants; use sef_from_all_invariants instead"
+        raise NotImplementedError(msg)
+
+    def sef_from_invariants(
+        self,
+        i1_bar: Symbol,
+        i2_bar: Symbol,
+        j: Symbol,
+        i4: Symbol | None = None,
+        i5: Symbol | None = None,
+    ) -> Expr:
+        msg = "PeirlinckArtery has 2 fibers; use sef_from_all_invariants instead"
+        raise NotImplementedError(msg)
+
+    def sef_from_all_invariants(
+        self,
+        i1_bar: Symbol,
+        i2_bar: Symbol,
+        j: Symbol,
+        fiber_invariants: list[tuple[Symbol, Symbol]] | None = None,
+    ) -> Expr:
+        mu1 = self._symbols["mu1"]
+        a_s = self._symbols["a"]
+        b_s = self._symbols["b"]
+        mu5 = self._symbols["mu5"]
+
+        W: Expr = (mu1 / 2) * (i1_bar - 3) + (a_s / (2 * b_s)) * (sympy_exp(b_s * (i1_bar - 3)) - 1)
+        if fiber_invariants is not None:
+            for _i4_k, i5_k in fiber_invariants:
+                W = W + (mu5 / 2) * (i5_k - 1) ** 2
+        return W + self._volumetric(j)
+
+    def evaluate_energy(self, c_batch: np.ndarray) -> np.ndarray:
+        """Evaluate strain energy via invariants (mirrors HolzapfelOgdenBiaxial)."""
+        from sympy import lambdify as sym_lambdify
+
+        from hyper_surrogate.mechanics.kinematics import Kinematics
+
+        i1s, i2s, js = Symbol("I1b"), Symbol("I2b"), Symbol("J")
+        fiber_inv_pairs: list[tuple[Symbol, Symbol]] = []
+        inv_syms: list[Symbol] = [i1s, i2s, js]
+        for k in range(self.num_fiber_families):
+            i4k, i5k = Symbol(f"I4_{k}"), Symbol(f"I5_{k}")
+            inv_syms.extend([i4k, i5k])
+            fiber_inv_pairs.append((i4k, i5k))
+
+        W = self.sef_from_all_invariants(i1s, i2s, js, fiber_inv_pairs)
+        param_syms = list(self._symbols.values())
+        fn = sym_lambdify((*inv_syms, *param_syms), W, modules="numpy")
+
+        i1 = Kinematics.isochoric_invariant1(c_batch)
+        i2 = Kinematics.isochoric_invariant2(c_batch)
+        j = np.sqrt(Kinematics.det_invariant(c_batch))
+
+        inv_vals: list[np.ndarray] = [i1, i2, j]
+        for a0 in self._fiber_directions:
+            inv_vals.append(Kinematics.fiber_invariant4(c_batch, a0))
+            inv_vals.append(Kinematics.fiber_invariant5(c_batch, a0))
+
+        param_vals = list(self._params.values())
+        results = fn(*inv_vals, *param_vals)
+        return np.asarray(results, dtype=float)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
   - Materials: materials.md
   - Tutorials:
       - Getting Started: tutorials/getting_started.md
+      - Custom Materials: tutorials/custom_materials.md
       - Data Generation: tutorials/data_generation.md
       - Training Surrogates: tutorials/training_surrogates.md
       - Fortran Export: tutorials/export_fortran.md

--- a/tests/test_data_dataset.py
+++ b/tests/test_data_dataset.py
@@ -83,3 +83,53 @@ class TestCreateDatasets:
         # energy target is (energy_scalar, dW_dI_3) = tuple of 2
         assert isinstance(y, tuple)
         assert y[1].shape == (3,)  # dW/d(invariants) matches input dim
+
+    def test_combined_compressible_inputs_have_J_variation(self):
+        """`deformation_mode='combined_compressible'` produces invariant
+        inputs whose J component genuinely varies (closes the J=1
+        training-data hole)."""
+        from hyper_surrogate.mechanics.materials import NeoHooke
+
+        material = NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+        train_ds, _val, in_norm, _out = create_datasets(
+            material,
+            n_samples=500,
+            input_type="invariants",
+            target_type="pk2_voigt",
+            deformation_mode="combined_compressible",
+            j_range=(0.85, 1.15),
+            seed=0,
+        )
+
+        # Inputs are normalised in storage; undo to inspect raw J.
+        all_inputs = np.array([train_ds[i][0] for i in range(len(train_ds))])
+        raw = all_inputs * in_norm.params["std"] + in_norm.params["mean"]
+        J = raw[:, 2]
+        # The combined deformation product means actual det F values can
+        # land outside [0.85, 1.15] (volumetric_dilation alone respects
+        # the range; combined() carries no det-F variation, so the
+        # product is bounded by the dilation factor).
+        assert J.min() >= 0.85 - 1e-6
+        assert J.max() <= 1.15 + 1e-6
+        assert J.std() > 0.04, "J variance must be substantially > 0 (not a J=1 grid)"
+
+    def test_combined_compressible_defaults_when_j_range_omitted(self):
+        """Omitting j_range falls back to the generator's default
+        (currently `[0.85, 1.15]`); test by exercising the code path
+        with no kwargs."""
+        from hyper_surrogate.mechanics.materials import NeoHooke
+
+        material = NeoHooke({"C10": 0.5, "KBULK": 1000.0})
+        # Just exercise the no-j_range branch; no assertion on the
+        # specific default beyond "the call succeeds and produces J
+        # variation".
+        train_ds, _val, in_norm, _out = create_datasets(
+            material,
+            n_samples=200,
+            input_type="invariants",
+            target_type="pk2_voigt",
+            deformation_mode="combined_compressible",
+            seed=0,
+        )
+        raw = np.array([train_ds[i][0] for i in range(len(train_ds))]) * in_norm.params["std"] + in_norm.params["mean"]
+        assert raw[:, 2].std() > 0.0

--- a/tests/test_data_deformation.py
+++ b/tests/test_data_deformation.py
@@ -47,3 +47,34 @@ def test_seed_reproducibility():
     F1 = gen1.combined(100)
     F2 = gen2.combined(100)
     np.testing.assert_array_equal(F1, F2)
+
+
+def test_volumetric_dilation_J_in_range():
+    gen = DeformationGenerator(seed=0)
+    F = gen.volumetric_dilation(1000, j_range=(0.85, 1.15))
+    J = np.linalg.det(F)
+    assert J.min() >= 0.85 - 1e-12
+    assert J.max() <= 1.15 + 1e-12
+    # Pure isotropic dilation: F should be a scalar multiple of I
+    np.testing.assert_allclose(F[:, 0, 1], 0.0, atol=1e-12)
+    np.testing.assert_allclose(F[:, 0, 0], F[:, 1, 1], atol=1e-12)
+    np.testing.assert_allclose(F[:, 1, 1], F[:, 2, 2], atol=1e-12)
+
+
+def test_combined_compressible_J_in_range():
+    gen = DeformationGenerator(seed=0)
+    F = gen.combined_compressible(2000, j_range=(0.85, 1.15))
+    J = np.linalg.det(F)
+    # det(A B) = det(A) det(B); det(combined) = 1, det(Fv) ∈ [0.85, 1.15]
+    assert J.min() >= 0.85 - 1e-9
+    assert J.max() <= 1.15 + 1e-9
+    # Sanity: shape, and that J is not concentrated at 1
+    assert F.shape == (2000, 3, 3)
+    assert J.std() > 0.05  # really spans the range
+
+
+def test_combined_compressible_reduces_to_combined_at_zero_dilation():
+    # j_range = (1.0, 1.0) -> Fv = I -> combined_compressible has det F = 1
+    gen = DeformationGenerator(seed=7)
+    F_cc = gen.combined_compressible(100, j_range=(1.0, 1.0))
+    np.testing.assert_allclose(np.linalg.det(F_cc), 1.0, atol=1e-12)

--- a/tests/test_hybrid_hessian.py
+++ b/tests/test_hybrid_hessian.py
@@ -14,6 +14,7 @@ from hyper_surrogate.data.dataset import Normalizer  # noqa: E402
 from hyper_surrogate.export.fortran.hybrid import HybridUMATEmitter  # noqa: E402
 from hyper_surrogate.export.weights import extract_weights  # noqa: E402
 from hyper_surrogate.models.mlp import MLP  # noqa: E402
+from hyper_surrogate.models.polyconvex import PolyconvexICNN  # noqa: E402
 
 
 def _make_model(activation="softplus", hidden_dims=None):
@@ -209,6 +210,353 @@ def test_d2act_sigmoid():
     sig = lambda x: 1.0 / (1.0 + np.exp(-x))
     d2_num = (sig(a + h) - 2 * sig(a) + sig(a - h)) / h**2
     np.testing.assert_allclose(d2act, d2_num, atol=1e-4)
+
+
+def _make_polyconvex_model(groups, hidden_dims=None):
+    if hidden_dims is None:
+        hidden_dims = [8, 8]
+    in_dim = max(idx for g in groups for idx in g) + 1
+    model = PolyconvexICNN(groups=groups, hidden_dims=hidden_dims, activation="softplus")
+    in_norm = Normalizer().fit(np.random.default_rng(42).standard_normal((50, in_dim)))
+    energy_norm = Normalizer().fit(np.random.default_rng(42).standard_normal((50, 1)))
+    return model, in_norm, energy_norm
+
+
+def _pytorch_polyconvex_hessian(model, in_norm, x_raw):
+    model.eval()
+    std = torch.tensor(in_norm.params["std"], dtype=torch.float32)
+    mean = torch.tensor(in_norm.params["mean"], dtype=torch.float32)
+
+    def f(x):
+        x_norm = (x - mean) / std
+        return model(x_norm.unsqueeze(0)).squeeze()
+
+    x_t = torch.tensor(x_raw, dtype=torch.float32)
+    return hessian(f, x_t).detach().numpy()
+
+
+def _polyconvex_emitter_hessian(model, in_norm, energy_norm, x_raw):
+    """Mirror hybrid.py:_emit_poly_nn_forward_and_backward (lines 416-592) in numpy."""
+    exported = extract_weights(model, in_norm, energy_norm)
+    weights = exported.weights
+    branches = exported.metadata["branches"]
+    in_std = exported.input_normalizer["std"]
+    in_mean = exported.input_normalizer["mean"]
+
+    x_norm = (x_raw - in_mean) / in_std
+    in_dim = len(x_norm)
+    d2W_dI2 = np.zeros((in_dim, in_dim))
+
+    def _softplus(w):
+        return np.log(1.0 + np.exp(w))
+
+    for bi, branch in enumerate(branches):
+        b_layers = branch["layers"]
+        indices = branch["input_indices"]
+        b_in = len(indices)
+        n_hidden = len(b_layers) - 1  # last entry is the identity output layer
+        prefix = f"branches.{bi}."
+        xb = x_norm[indices]
+
+        # Forward pass (softplus everywhere on hidden layers)
+        a_arr, dact_arr, d2act_arr, z_arr = [], [], [], []
+
+        # Layer 0: x-path only
+        W0 = weights[b_layers[0]["weights"]]
+        b0 = weights[b_layers[0]["bias"]]
+        a0 = W0 @ xb + b0
+        z0 = _softplus(a0)
+        da0 = 1.0 / (1.0 + np.exp(-a0))
+        a_arr.append(a0)
+        z_arr.append(z0)
+        dact_arr.append(da0)
+        d2act_arr.append(da0 * (1.0 - da0))
+
+        # Hidden layers 1..n_hidden-1: wz (softplus on raw) + wx skip
+        for li in range(1, n_hidden):
+            wz = _softplus(weights[b_layers[li]["weights"]])
+            wx = weights[prefix + f"wx_layers.{li}.weight"]
+            bli = weights[b_layers[li]["bias"]]
+            ali = wz @ z_arr[li - 1] + wx @ xb + bli
+            zli = _softplus(ali)
+            dali = 1.0 / (1.0 + np.exp(-ali))
+            a_arr.append(ali)
+            z_arr.append(zli)
+            dact_arr.append(dali)
+            d2act_arr.append(dali * (1.0 - dali))
+
+        # Output (identity, linear): only need wz_out for backward init
+        last_hidden = n_hidden - 1
+        wz_out = _softplus(weights[b_layers[n_hidden]["weights"]])  # shape (1, hidden)
+
+        # Backward pass: deltas[li] = ∂Ψ_branch / ∂a^(li)
+        deltas: list = [None] * n_hidden
+        deltas[last_hidden] = wz_out[0, :] * dact_arr[last_hidden]
+        for li in range(last_hidden - 1, -1, -1):
+            wz_next = _softplus(weights[b_layers[li + 1]["weights"]])
+            deltas[li] = (wz_next.T @ deltas[li + 1]) * dact_arr[li]
+
+        # Jacobian propagation: P^(l) = d a^(l)/d xb (with ICNN skip on layer >= 1)
+        Ps, Js = [], []
+        P0 = W0.copy()
+        Ps.append(P0)
+        Js.append(np.diag(dact_arr[0]) @ P0)
+        for li in range(1, n_hidden):
+            wz = _softplus(weights[b_layers[li]["weights"]])
+            wx = weights[prefix + f"wx_layers.{li}.weight"]
+            Pli = wz @ Js[li - 1] + wx
+            Ps.append(Pli)
+            Js.append(np.diag(dact_arr[li]) @ Pli)
+
+        # Per-branch Hessian
+        d2W_b = np.zeros((b_in, b_in))
+        for li in range(n_hidden):
+            for j in range(len(dact_arr[li])):
+                coeff = deltas[li][j] / dact_arr[li][j] * d2act_arr[li][j]
+                d2W_b += coeff * np.outer(Ps[li][j, :], Ps[li][j, :])
+
+        # Scatter (block at indices, divide by std*std)
+        for si, idx_i in enumerate(indices):
+            for sj, idx_j in enumerate(indices):
+                d2W_dI2[idx_i, idx_j] += d2W_b[si, sj] / (in_std[idx_i] * in_std[idx_j])
+
+    return d2W_dI2
+
+
+@pytest.mark.parametrize(
+    "groups",
+    [
+        [[0], [1], [2]],  # isotropic 3-group (I1, I2, J)
+        [[0], [1], [2], [3, 4]],  # anisotropic 4-group with 2-D fiber subspace
+    ],
+)
+def test_polyconvex_hessian_matches_pytorch(groups):
+    """Polyconvex emitter Hessian matches PyTorch autograd on random-init weights."""
+    model, in_norm, energy_norm = _make_polyconvex_model(groups, hidden_dims=[8, 8])
+    in_dim = max(idx for g in groups for idx in g) + 1
+    rng = np.random.default_rng(789)
+    x_raw = rng.standard_normal(in_dim).astype(np.float64)
+
+    H_torch = _pytorch_polyconvex_hessian(model, in_norm, x_raw)
+    H_analytical = _polyconvex_emitter_hessian(model, in_norm, energy_norm, x_raw)
+
+    np.testing.assert_allclose(H_analytical, H_torch, atol=1e-5, rtol=1e-4)
+
+
+def test_polyconvex_hessian_singleton_groups_are_diagonal():
+    """Singleton groups [[0],[1],[2]] -> Hessian is purely diagonal (no cross-group coupling)."""
+    model, in_norm, energy_norm = _make_polyconvex_model([[0], [1], [2]], hidden_dims=[8, 8])
+    rng = np.random.default_rng(321)
+    x_raw = rng.standard_normal(3).astype(np.float64)
+
+    H = _polyconvex_emitter_hessian(model, in_norm, energy_norm, x_raw)
+    off_diag = H - np.diag(np.diag(H))
+    np.testing.assert_allclose(off_diag, 0.0, atol=1e-12)
+
+
+def test_polyconvex_hessian_cross_group_off_diagonals_are_zero():
+    """For groups [[0],[1],[2],[3,4]], H[i,j] must be zero when i,j fall in different groups."""
+    groups = [[0], [1], [2], [3, 4]]
+    model, in_norm, energy_norm = _make_polyconvex_model(groups, hidden_dims=[8, 8])
+    rng = np.random.default_rng(654)
+    x_raw = rng.standard_normal(5).astype(np.float64)
+
+    H = _polyconvex_emitter_hessian(model, in_norm, energy_norm, x_raw)
+    cross_pairs = [(i, j) for i in [0, 1, 2] for j in [3, 4]]
+    for i, j in cross_pairs:
+        assert abs(H[i, j]) < 1e-12 and abs(H[j, i]) < 1e-12, f"H[{i},{j}]={H[i, j]} not zero"
+
+
+@pytest.mark.parametrize("hidden_dims", [[16], [4, 4, 4]])
+def test_polyconvex_hessian_various_depths(hidden_dims):
+    """Polyconvex Hessian matches PyTorch across branch depths."""
+    groups = [[0], [1], [2]]
+    model, in_norm, energy_norm = _make_polyconvex_model(groups, hidden_dims=hidden_dims)
+    rng = np.random.default_rng(987)
+    x_raw = rng.standard_normal(3).astype(np.float64)
+
+    H_torch = _pytorch_polyconvex_hessian(model, in_norm, x_raw)
+    H_analytical = _polyconvex_emitter_hessian(model, in_norm, energy_norm, x_raw)
+
+    np.testing.assert_allclose(H_analytical, H_torch, atol=1e-5, rtol=1e-4)
+
+
+def _make_mlp_with_input_dim(input_dim, activation="softplus", hidden_dims=None):
+    if hidden_dims is None:
+        hidden_dims = [8, 8]
+    model = MLP(input_dim=input_dim, output_dim=1, hidden_dims=hidden_dims, activation=activation)
+    in_norm = Normalizer().fit(np.random.default_rng(42).standard_normal((50, input_dim)))
+    energy_norm = Normalizer().fit(np.random.default_rng(42).standard_normal((50, 1)))
+    return model, in_norm, energy_norm
+
+
+def _pytorch_hessian_anyD(model, in_norm, x_raw):
+    model.eval()
+    std = torch.tensor(in_norm.params["std"], dtype=torch.float32)
+    mean = torch.tensor(in_norm.params["mean"], dtype=torch.float32)
+
+    def f(x):
+        x_norm = (x - mean) / std
+        return model(x_norm.unsqueeze(0)).squeeze()
+
+    return hessian(f, torch.tensor(x_raw, dtype=torch.float32)).detach().numpy()
+
+
+@pytest.mark.parametrize("input_dim", [3, 5])
+def test_mlp_hessian_matches_pytorch_input_dim(input_dim):
+    """MLP Hessian matches PyTorch for both isotropic (3) and anisotropic (5) input shapes."""
+    model, in_norm, energy_norm = _make_mlp_with_input_dim(input_dim, hidden_dims=[8, 8])
+    rng = np.random.default_rng(2024)
+    x_raw = rng.standard_normal(input_dim).astype(np.float64)
+
+    H_torch = _pytorch_hessian_anyD(model, in_norm, x_raw)
+    H_analytical = _emitter_hessian(model, in_norm, energy_norm, x_raw)
+
+    np.testing.assert_allclose(H_analytical, H_torch, atol=1e-5, rtol=1e-4)
+
+
+def test_mlp_hessian_trained_at_saturated_activations():
+    """After brief training, Hessian still matches PyTorch at points spanning the training domain.
+
+    The codegen's `delta/dact * d2act` division has its largest numerical exposure when softplus
+    pre-activations saturate (small dact). This test exercises that regime on trained weights.
+    """
+    torch.manual_seed(0)
+    np.random.seed(0)
+    input_dim = 3
+    model = MLP(input_dim=input_dim, output_dim=1, hidden_dims=[16, 16], activation="softplus")
+
+    # Synthetic Neo-Hookean-like target: W = 0.5 * (I1 - 3) + 50 * (J - 1)^2 on (I1, I2, J).
+    rng = np.random.default_rng(0)
+    n = 256
+    x_train = rng.uniform(low=[2.7, 2.7, 0.85], high=[3.5, 3.5, 1.15], size=(n, 3)).astype(np.float32)
+    w_train = (0.5 * (x_train[:, 0:1] - 3.0) + 50.0 * (x_train[:, 2:3] - 1.0) ** 2).astype(np.float32)
+
+    in_norm = Normalizer().fit(x_train)
+    energy_norm = Normalizer().fit(w_train)
+
+    x_t = torch.tensor((x_train - in_norm.params["mean"]) / in_norm.params["std"])
+    w_t = torch.tensor(w_train)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-2)
+    for _ in range(50):
+        opt.zero_grad()
+        loss = ((model(x_t) - w_t) ** 2).mean()
+        loss.backward()
+        opt.step()
+
+    probe_points = [
+        np.array([2.7, 2.7, 0.85], dtype=np.float64),  # corner of training domain
+        np.array([3.5, 3.5, 1.15], dtype=np.float64),  # opposite corner
+        np.array([3.1, 3.0, 1.00], dtype=np.float64),  # near reference (I=identity)
+    ]
+    for x_raw in probe_points:
+        H_torch = _pytorch_hessian_anyD(model, in_norm, x_raw)
+        H_analytical = _emitter_hessian(model, in_norm, energy_norm, x_raw)
+        np.testing.assert_allclose(H_analytical, H_torch, atol=1e-5, rtol=1e-4)
+
+
+def test_reference_offset_makes_energy_zero_at_C_eq_I():
+    """The hybrid emitter subtracts Psi(reference) so Psi(C=I)=0 exactly.
+
+    Without the offset, the trained model emits a small residual energy at
+    the reference configuration; the emitter pre-computes this value and
+    embeds the subtraction as W_REF_OFFSET. Verifies the numpy mirror of
+    the Fortran path returns ~0 at the reference point.
+    """
+    model, in_norm, energy_norm = _make_model(activation="softplus", hidden_dims=[8, 8])
+    exported = extract_weights(model, in_norm, energy_norm)
+    emitter = HybridUMATEmitter(exported, enforce_stress_free_reference=True)
+    code = emitter.emit()
+    assert "W_REF_OFFSET" in code, "emitted UMAT must declare the reference-offset PARAMETER"
+    assert "W_nn = z" in code and "- W_REF_OFFSET" in code, "W_nn output must subtract W_REF_OFFSET"
+
+    # Verify the numerical offset matches the model's prediction at C=I.
+    in_dim = exported.metadata["input_dim"]
+    x_ref = np.array([3.0, 3.0, 1.0] + [1.0] * (in_dim - 3))
+    mean = np.asarray(in_norm.params["mean"], dtype=float)
+    std = np.asarray(in_norm.params["std"], dtype=float)
+    x_norm = (x_ref - mean) / std
+    x_t = torch.tensor(x_norm, dtype=torch.float32).unsqueeze(0)
+    model.eval()
+    W_ref_torch = float(model(x_t).detach().numpy().flatten()[0])
+    np.testing.assert_allclose(emitter._W_ref, W_ref_torch, atol=1e-5, rtol=1e-4)
+
+    # And confirm the offset can be disabled.
+    emitter_off = HybridUMATEmitter(exported, enforce_stress_free_reference=False)
+    assert emitter_off._W_ref == 0.0
+    assert "W_REF_OFFSET = 0.0" in emitter_off.emit() or "0.000000000000000e+00" in emitter_off.emit()
+
+
+def test_reference_gradient_makes_stress_zero_at_C_eq_I():
+    """The hybrid emitter subtracts dW/dI(C=I) for non-deviatoric invariants
+    so that sigma(C=I) = 0 exactly at deployment.
+
+    The deviatoric invariants Ī₁, Ī₂ have dI/dC|_{C=I} = 0, so the trained
+    gradient on those components never reaches sigma at the reference and
+    is left untouched (the corresponding entries of dW_dI_REF are masked
+    to zero).  J (and any fiber invariants) have dI/dC|_{C=I} ≠ 0, so the
+    trained gradient there directly biases sigma(C=I).  The emitter
+    embeds dW/dI at reference as a PARAMETER array and the Fortran
+    subtracts it from the runtime gradient.  This test verifies:
+
+    1. dW_dI_REF is present in the emitted code and used in the subtraction;
+    2. components 0 and 1 (Ī₁, Ī₂) of dW_dI_REF are exactly zero (masked);
+    3. component 2+ (J, optional I4, I5) match the model's trained
+       gradient at the reference (computed by autograd);
+    4. with the correction enabled, the numpy-mirror chain rule yields
+       sigma(C=I) = 0 to floating-point precision;
+    5. the correction can be disabled via enforce_stress_free_reference=False.
+    """
+    model, in_norm, energy_norm = _make_model(activation="softplus", hidden_dims=[8, 8])
+    exported = extract_weights(model, in_norm, energy_norm)
+    emitter = HybridUMATEmitter(exported, enforce_stress_free_reference=True)
+    code = emitter.emit()
+
+    # 1. Fortran has dW_dI_REF and the subtraction.
+    assert "dW_dI_REF" in code, "emitted UMAT must declare dW_dI_REF PARAMETER"
+    assert "dW_dI(1) = dW_dI(1) - dW_dI_REF(1)" in code, "runtime subtraction missing"
+
+    in_dim = exported.metadata["input_dim"]
+    dW_dI_ref = np.asarray(emitter._dW_dI_ref, dtype=float)
+    assert dW_dI_ref.shape == (in_dim,)
+
+    # 2. Deviatoric components must be exactly zero (the mask).
+    np.testing.assert_array_equal(dW_dI_ref[:2], 0.0)
+
+    # 3. Component 2+ must match the trained model's autograd gradient at
+    #    reference (in raw-invariant space, i.e. divided by in_std).
+    x_ref = np.array([3.0, 3.0, 1.0] + [1.0] * (in_dim - 3))
+    mean = np.asarray(in_norm.params["mean"], dtype=float)
+    std = np.asarray(in_norm.params["std"], dtype=float)
+    x_norm = (x_ref - mean) / std
+    model.eval()
+    x_t = torch.tensor(x_norm, dtype=torch.float32, requires_grad=True).unsqueeze(0)
+    W = model(x_t)
+    dW_dx_norm = torch.autograd.grad(W.sum(), x_t)[0].detach().numpy().flatten()
+    dW_dI_autograd = dW_dx_norm / std
+    np.testing.assert_allclose(
+        dW_dI_ref[2:],
+        dW_dI_autograd[2:],
+        atol=1e-4,
+        rtol=1e-3,
+        err_msg="dW_dI_REF[2:] must equal trained autograd gradient on J/fiber invariants",
+    )
+
+    # 4. Numpy mirror of the Fortran chain rule at C=I yields sigma = 0.
+    #    Only dJ/dC|_{C=I} = 0.5 I is non-zero; the deviatoric chain-rule
+    #    weights vanish.  Pushing the corrected dW/dJ through gives sigma ~ 0.
+    eye = np.eye(3)
+    dJ_dC = 0.5 * eye
+    S = 2.0 * (dW_dI_autograd[2] - dW_dI_ref[2]) * dJ_dC
+    sigma = eye @ S @ eye.T
+    # Residual comes from the finite-difference precision of
+    # _compute_reference_gradient (eps=1e-5 -> ~1e-9 residual on dW/dJ);
+    # ~10 orders of magnitude below typical Cauchy stress in MPa.
+    np.testing.assert_allclose(sigma, 0.0, atol=1e-8, err_msg="sigma(C=I) must be near-zero after dW_dI_REF correction")
+
+    # 5. Disabling the correction zeroes dW_dI_REF.
+    emitter_off = HybridUMATEmitter(exported, enforce_stress_free_reference=False)
+    np.testing.assert_array_equal(emitter_off._dW_dI_ref, np.zeros(in_dim))
 
 
 def test_generated_fortran_has_d2act_no_eps_fd():

--- a/tests/test_hybrid_hessian.py
+++ b/tests/test_hybrid_hessian.py
@@ -323,6 +323,105 @@ def _polyconvex_emitter_hessian(model, in_norm, energy_norm, x_raw):
     return d2W_dI2
 
 
+def _polyconvex_emitter_gradient(model, in_norm, energy_norm, x_raw):
+    """Mirror hybrid.py:_emit_poly_nn_forward_and_backward GRADIENT path in numpy.
+    This is the regression guard for the ICNN skip-connection backward bug
+    (Fortran was previously omitting wx_l^T·delta_l for l>=1, producing a
+    non-zero residual gradient that surfaced in Abaqus as a several-MPa
+    spurious hydrostatic stress).
+    """
+    exported = extract_weights(model, in_norm, energy_norm)
+    weights = exported.weights
+    branches = exported.metadata["branches"]
+    in_std = exported.input_normalizer["std"]
+    in_mean = exported.input_normalizer["mean"]
+    x_norm = (x_raw - in_mean) / in_std
+
+    def _softplus(w):
+        return np.log(1.0 + np.exp(w))
+
+    dW_dI = np.zeros_like(x_raw)
+    for bi, branch in enumerate(branches):
+        b_layers = branch["layers"]
+        indices = branch["input_indices"]
+        n_hidden = len(b_layers) - 1
+        prefix = f"branches.{bi}."
+        xb = x_norm[indices]
+
+        # Forward (softplus weights on hidden+output, raw wx skips)
+        W0 = weights[b_layers[0]["weights"]]
+        b0 = weights[b_layers[0]["bias"]]
+        a0 = W0 @ xb + b0
+        a_arr = [a0]
+        z_arr = [_softplus(a0)]
+        dact_arr = [1.0 / (1.0 + np.exp(-a0))]
+        for li in range(1, n_hidden):
+            wz = _softplus(weights[b_layers[li]["weights"]])
+            wx = weights[prefix + f"wx_layers.{li}.weight"]
+            bli = weights[b_layers[li]["bias"]]
+            ali = wz @ z_arr[li - 1] + wx @ xb + bli
+            a_arr.append(ali)
+            z_arr.append(_softplus(ali))
+            dact_arr.append(1.0 / (1.0 + np.exp(-ali)))
+        wz_out = _softplus(weights[b_layers[n_hidden]["weights"]])
+        wxf = weights[prefix + "wx_final.weight"]
+
+        # Backward — propagate deltas
+        last_h = n_hidden - 1
+        deltas = [None] * n_hidden
+        deltas[last_h] = wz_out[0, :] * dact_arr[last_h]
+        for li in range(last_h - 1, -1, -1):
+            wz_next = _softplus(weights[b_layers[li + 1]["weights"]])
+            deltas[li] = (wz_next.T @ deltas[li + 1]) * dact_arr[li]
+
+        # Gradient w.r.t. branch input: wxf + W0^T·δ_0 + Σ_{l≥1} wx_l^T·δ_l
+        grad = wxf.flatten() + W0.T @ deltas[0]
+        for li in range(1, n_hidden):
+            wx = weights[prefix + f"wx_layers.{li}.weight"]
+            grad = grad + wx.T @ deltas[li]
+
+        # Scatter, undoing the input normalization
+        for si, idx in enumerate(indices):
+            dW_dI[idx] += grad[si] / in_std[idx]
+    return dW_dI
+
+
+def _pytorch_polyconvex_gradient(model, in_norm, x_raw):
+    model.eval()
+    std = torch.tensor(in_norm.params["std"], dtype=torch.float32)
+    mean = torch.tensor(in_norm.params["mean"], dtype=torch.float32)
+    x = torch.tensor(x_raw, dtype=torch.float32, requires_grad=True)
+    W = model(((x - mean) / std).unsqueeze(0)).squeeze()
+    g = torch.autograd.grad(W, x)[0]
+    return g.detach().numpy()
+
+
+@pytest.mark.parametrize(
+    "groups",
+    [
+        [[0], [1], [2]],
+        [[0], [1], [2], [3, 4]],
+    ],
+)
+def test_polyconvex_emitter_gradient_matches_pytorch(groups):
+    """Emitter's GRADIENT path (not just Hessian) must match autograd.
+
+    Regression: the .f90 backward was missing wx_l^T·delta_l for l>=1,
+    producing a non-zero residual gradient that an Abaqus run surfaced
+    as a ~7 MPa spurious hydrostatic Cauchy stress at C=I.  See Lesson 9
+    in tasks/lessons.md.
+    """
+    model, in_norm, energy_norm = _make_polyconvex_model(groups, hidden_dims=[8, 8])
+    in_dim = max(idx for g in groups for idx in g) + 1
+    rng = np.random.default_rng(456)
+    x_raw = rng.standard_normal(in_dim).astype(np.float64)
+
+    g_torch = _pytorch_polyconvex_gradient(model, in_norm, x_raw)
+    g_emit = _polyconvex_emitter_gradient(model, in_norm, energy_norm, x_raw)
+
+    np.testing.assert_allclose(g_emit, g_torch, atol=1e-5, rtol=1e-4)
+
+
 @pytest.mark.parametrize(
     "groups",
     [
@@ -586,6 +685,33 @@ def test_polyconvex_emits_dW_dI_REF_inside_module():
     assert mod_start < decl < mod_end, "dW_dI_REF declaration must be inside MODULE nn_sef"
     for s in subs:
         assert mod_start < s < mod_end, "dW_dI_REF subtraction must be inside MODULE nn_sef"
+
+
+def test_polyconvex_emits_wx_skip_grad_contributions_in_backward():
+    """The polyconvex backward pass must include the ICNN skip-connection
+    gradient contributions `wx_b{bi}_{li}(jj, ii) * delta_b{bi}_{li}(jj)`
+    for every hidden layer l >= 1.  Without these, the emitted dW/dI is
+    incomplete and produces a non-zero residual at the reference -- which
+    surfaced in Abaqus as a multi-MPa spurious hydrostatic Cauchy stress
+    on the J branch (Sep 2026 incident; see tasks/lessons.md Lesson 9).
+    """
+    poly = PolyconvexICNN(groups=[[0], [1], [2]], hidden_dims=[4, 4, 4], activation="softplus")
+    rng = np.random.default_rng(0)
+    in_norm = Normalizer().fit(rng.standard_normal((50, 3)))
+    energy_norm = Normalizer().fit(rng.standard_normal((50, 1)))
+    exported = extract_weights(poly, in_norm, energy_norm)
+    code = HybridUMATEmitter(exported, enforce_stress_free_reference=True).emit()
+
+    # With hidden_dims=[4,4,4], n_hidden=3 so wx skip exists at li=1 and li=2.
+    # Each branch (3 branches in groups [[0],[1],[2]]) must emit two
+    # gradient-accumulation lines: wx_b{bi}_1·delta and wx_b{bi}_2·delta.
+    for bi in range(3):
+        for li in (1, 2):
+            needle = f"grad_b{bi}(ii) = grad_b{bi}(ii) + wx_b{bi}_{li}(jj, ii) * delta_b{bi}_{li}(jj)"
+            assert needle in code, (
+                f"polyconvex emitter must accumulate wx_b{bi}_{li}^T·delta_{li} into grad_b{bi}; "
+                f"missing line: {needle!r}"
+            )
 
 
 def test_generated_fortran_has_d2act_no_eps_fd():

--- a/tests/test_hybrid_hessian.py
+++ b/tests/test_hybrid_hessian.py
@@ -559,6 +559,35 @@ def test_reference_gradient_makes_stress_zero_at_C_eq_I():
     np.testing.assert_array_equal(emitter_off._dW_dI_ref, np.zeros(in_dim))
 
 
+def test_polyconvex_emits_dW_dI_REF_inside_module():
+    """Polyconvex emitter declares dW_dI_REF inside the nn_sef module so
+    that the subsequent `dW_dI(k) = dW_dI(k) - dW_dI_REF(k)` lines (also
+    emitted inside the module's nn_eval body) reference an in-scope
+    PARAMETER.  Regression for an emitter bug where the MLP variant of
+    `_emit_..._nn_parameters` declared dW_dI_REF but the polyconvex
+    variant did not, causing gfortran to error with
+    `Function 'dw_di_ref' has no IMPLICIT type` on the subtraction lines.
+    """
+    rng = np.random.default_rng(0)
+    in_norm = Normalizer().fit(rng.standard_normal((50, 3)))
+    energy_norm = Normalizer().fit(rng.standard_normal((50, 1)))
+    poly = PolyconvexICNN(groups=[[0], [1], [2]], hidden_dims=[4, 4], activation="softplus")
+    exported = extract_weights(poly, in_norm, energy_norm)
+    emitter = HybridUMATEmitter(exported, enforce_stress_free_reference=True)
+    code = emitter.emit()
+
+    # Locate the nn_sef module boundary and the subtraction lines.
+    lines = code.splitlines()
+    mod_start = next(i for i, ln in enumerate(lines) if ln.strip().startswith("MODULE nn_sef"))
+    mod_end = next(i for i, ln in enumerate(lines) if ln.strip().startswith("END MODULE nn_sef"))
+    decl = next(i for i, ln in enumerate(lines) if "PARAMETER :: dW_dI_REF" in ln)
+    subs = [i for i, ln in enumerate(lines) if "dW_dI(1) = dW_dI(1) - dW_dI_REF(1)" in ln]
+    assert subs, "polyconvex emitter must emit dW_dI(k) - dW_dI_REF(k) lines"
+    assert mod_start < decl < mod_end, "dW_dI_REF declaration must be inside MODULE nn_sef"
+    for s in subs:
+        assert mod_start < s < mod_end, "dW_dI_REF subtraction must be inside MODULE nn_sef"
+
+
 def test_generated_fortran_has_d2act_no_eps_fd():
     """Generated Fortran should contain d2act but not eps_fd."""
     model, in_norm, energy_norm = _make_model(activation="softplus")

--- a/tests/test_peirlinck_artery.py
+++ b/tests/test_peirlinck_artery.py
@@ -1,0 +1,183 @@
+"""Tests for the PeirlinckArtery two-fiber arterial SEF.
+
+Mirrors the testing pattern from test_holzapfel_ogden.py; covers the
+public API (instantiation, classmethods, the two NotImplementedError
+surfaces, custom parameters, fiber-direction validation) and the
+energy evaluation at the reference configuration and a simple
+biaxial state.
+"""
+
+import numpy as np
+import pytest
+from sympy import Symbol
+
+from hyper_surrogate.mechanics.materials import PeirlinckArtery
+
+
+def _identity_batch(n=1):
+    return np.tile(np.eye(3), (n, 1, 1))
+
+
+def _equibiaxial_C(stretch: float) -> np.ndarray:
+    """C for incompressible equibiaxial in the (1,2) plane: F = diag(λ, λ, 1/λ²)."""
+    F = np.diag([stretch, stretch, stretch**-2])
+    return (F.T @ F).reshape(1, 3, 3)
+
+
+# ── Construction ─────────────────────────────────────────────────────
+
+
+def test_default_parameters_are_media_layer():
+    """DEFAULT_PARAMS matches the media-layer parameter set from Peirlinck 2024."""
+    mat = PeirlinckArtery()
+    assert mat._params["mu1"] == 33.45
+    assert mat._params["a"] == 3.74
+    assert mat._params["b"] == 6.66
+    assert mat._params["mu5"] == 2.17
+    assert mat._params["KBULK"] == 1000.0
+
+
+def test_default_fiber_directions_are_symmetric_at_7deg():
+    """No-arg construction yields two fibers at ±7° from circumferential."""
+    mat = PeirlinckArtery()
+    a0, a1 = mat._fiber_directions
+    theta = np.radians(7.0)
+    np.testing.assert_allclose(a0, [np.cos(theta), np.sin(theta), 0.0], atol=1e-12)
+    np.testing.assert_allclose(a1, [np.cos(theta), -np.sin(theta), 0.0], atol=1e-12)
+
+
+def test_is_anisotropic():
+    assert PeirlinckArtery().is_anisotropic
+    assert PeirlinckArtery().num_fiber_families == 2
+
+
+# ── Classmethod factories ────────────────────────────────────────────
+
+
+def test_media_factory_matches_default():
+    """`PeirlinckArtery.media()` reproduces the default parameter set."""
+    media = PeirlinckArtery.media()
+    default = PeirlinckArtery()
+    assert media._params == default._params
+    np.testing.assert_allclose(media._fiber_directions, default._fiber_directions, atol=1e-12)
+
+
+def test_adventitia_factory_overrides_parameters_and_angle():
+    """`PeirlinckArtery.adventitia()` shifts mu1/a/b/mu5 and fiber angle to 66.78°."""
+    adv = PeirlinckArtery.adventitia()
+    assert adv._params["mu1"] == 8.30
+    assert adv._params["a"] == 1.42
+    assert adv._params["b"] == 6.34
+    assert adv._params["mu5"] == 0.49
+    a0, a1 = adv._fiber_directions
+    theta = np.radians(66.78)
+    np.testing.assert_allclose(a0, [np.cos(theta), np.sin(theta), 0.0], atol=1e-10)
+    np.testing.assert_allclose(a1, [np.cos(theta), -np.sin(theta), 0.0], atol=1e-10)
+
+
+# ── Construction-time validation ─────────────────────────────────────
+
+
+def test_construction_rejects_wrong_number_of_fibers():
+    """Exactly two fiber directions are required."""
+    one_fiber = [np.array([1.0, 0.0, 0.0])]
+    with pytest.raises(ValueError, match="exactly 2 fiber directions"):
+        PeirlinckArtery(fiber_directions=one_fiber)
+
+    three_fibers = [
+        np.array([1.0, 0.0, 0.0]),
+        np.array([0.0, 1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+    ]
+    with pytest.raises(ValueError, match="exactly 2 fiber directions"):
+        PeirlinckArtery(fiber_directions=three_fibers)
+
+
+def test_custom_parameters_override_defaults():
+    mat = PeirlinckArtery(parameters={"mu1": 50.0, "b": 10.0})
+    assert mat._params["mu1"] == 50.0
+    assert mat._params["b"] == 10.0
+    # Untouched parameters fall back to defaults
+    assert mat._params["a"] == 3.74
+    assert mat._params["mu5"] == 2.17
+    assert mat._params["KBULK"] == 1000.0
+
+
+def test_custom_fiber_angle_overrides_default():
+    """A user-supplied `fiber_angle_deg` builds symmetric fibers at ±angle."""
+    mat = PeirlinckArtery(fiber_angle_deg=45.0)
+    a0, a1 = mat._fiber_directions
+    theta = np.radians(45.0)
+    np.testing.assert_allclose(a0, [np.cos(theta), np.sin(theta), 0.0], atol=1e-12)
+    np.testing.assert_allclose(a1, [np.cos(theta), -np.sin(theta), 0.0], atol=1e-12)
+
+
+# ── SEF surfaces (isotropic API explicitly disallowed) ───────────────
+
+
+def test_isotropic_sef_property_is_not_implemented():
+    """The 2-fiber SEF cannot be expressed without fiber invariants."""
+    with pytest.raises(NotImplementedError, match="sef_from_all_invariants"):
+        _ = PeirlinckArtery().sef
+
+
+def test_isotropic_sef_from_invariants_is_not_implemented():
+    """sef_from_invariants is the single-fiber convenience API; not valid here."""
+    mat = PeirlinckArtery()
+    with pytest.raises(NotImplementedError, match="sef_from_all_invariants"):
+        mat.sef_from_invariants(Symbol("I1b"), Symbol("I2b"), Symbol("J"))
+
+
+def test_sef_from_all_invariants_at_reference_equals_zero():
+    """W(C=I) with both fiber I5 = 1 should be zero."""
+    mat = PeirlinckArtery()
+    i1, i2, j = Symbol("I1b"), Symbol("I2b"), Symbol("J")
+    i4_0, i5_0 = Symbol("I4_0"), Symbol("I5_0")
+    i4_1, i5_1 = Symbol("I4_1"), Symbol("I5_1")
+    W_expr = mat.sef_from_all_invariants(i1, i2, j, [(i4_0, i5_0), (i4_1, i5_1)])
+
+    # At C=I: I1=3, I2=3, J=1, I4=I5=1. W must collapse to zero.
+    subs = {i1: 3.0, i2: 3.0, j: 1.0, i4_0: 1.0, i5_0: 1.0, i4_1: 1.0, i5_1: 1.0}
+    for s, v in mat._symbols.items():
+        subs[v] = float(mat._params[s])
+    assert float(W_expr.subs(subs)) == pytest.approx(0.0, abs=1e-12)
+
+
+# ── Numerical energy evaluation ──────────────────────────────────────
+
+
+def test_evaluate_energy_at_identity_is_zero():
+    """No deformation -> zero strain energy."""
+    mat = PeirlinckArtery()
+    W = mat.evaluate_energy(_identity_batch())
+    np.testing.assert_allclose(W, 0.0, atol=1e-10)
+
+
+def test_evaluate_energy_positive_under_biaxial_stretch():
+    """A non-trivial equibiaxial stretch produces strictly positive energy."""
+    mat = PeirlinckArtery()
+    W = mat.evaluate_energy(_equibiaxial_C(1.1))
+    assert W[0] > 0.0
+
+
+def test_evaluate_energy_adventitia_is_softer_than_media_at_same_strain():
+    """Adventitia parameters are softer than media; energy reflects that."""
+    media = PeirlinckArtery.media()
+    adventitia = PeirlinckArtery.adventitia()
+    C = _equibiaxial_C(1.1)
+    # Note that the materials have different fiber directions, so the
+    # comparison fairness isn't perfect, but the deviatoric-isotropic
+    # part (mu1) is the dominant driver and mu1_media >> mu1_adv.
+    W_media = media.evaluate_energy(C)
+    W_adventitia = adventitia.evaluate_energy(C)
+    assert W_media[0] > W_adventitia[0]
+
+
+def test_evaluate_energy_batch_consistency():
+    """Batched evaluation matches independent calls."""
+    mat = PeirlinckArtery()
+    C_batch = np.concatenate([_equibiaxial_C(1.05), _equibiaxial_C(1.1)])
+    W_batch = mat.evaluate_energy(C_batch)
+    W_a = mat.evaluate_energy(_equibiaxial_C(1.05))
+    W_b = mat.evaluate_energy(_equibiaxial_C(1.1))
+    np.testing.assert_allclose([W_batch[0], W_batch[1]], [W_a[0], W_b[0]], atol=1e-12)


### PR DESCRIPTION
## Summary

Closes the J=1-training-data and σ(C=I)≠0 deployment gaps that
prevented trained NN constitutive surrogates from agreeing with the
analytical reference inside compressible FE solvers.

- `DeformationGenerator` gains `volumetric_dilation` and
  `combined_compressible` modes (J sampled in `j_range`, default
  `[0.85, 1.15]`), giving the surrogate real J-direction training
  signal.
- `create_datasets` accepts `deformation_mode=\"combined_compressible\"`
  and a `j_range` kwarg.
- `HybridUMATEmitter` computes `dW/dI` at the reference configuration
  via finite differences over the numpy mirror of its forward pass,
  masks out the deviatoric components (Ī₁, Ī₂ whose `dI/dC` vanishes
  at C=I), and embeds the result as a `dW_dI_REF` `PARAMETER` array.
  The emitted Fortran subtracts it from the runtime gradient so that
  σ(C=I) = 0 exactly — analogue of the existing `W_REF_OFFSET` which
  zeros the energy at reference.
- `materials.PeirlinckArtery` — universal soft-matter SEF from
  Peirlinck et al., EwC 2024 (`10.1007/s00366-024-02031-w`).
- Two new regression tests (`test_data_deformation.py`,
  `test_hybrid_hessian.py`); all 48 hybrid/data tests pass.

Python-side verification on a polyconvex Neo-Hookean surrogate vs the
analytical reference at compressible-equilibrium F:

| mode      | before | after |
|-----------|--------|-------|
| uniaxial  | 33–93 % | 1.3–1.7 % |
| biaxial   | 22–33 % | 2.2–2.3 % |
| shear     | 920 %   | 0.7–1.0 % |

## Test plan

- [x] `uv run pytest tests/test_data_deformation.py tests/test_hybrid_hessian.py tests/test_hybrid_emitter.py` — 48 pass
- [x] Python-side numerical verification (table above)
- [ ] Abaqus single-element round-trip on `turin` (bundle in
      `paper/results/fe_validation/abaqus_bundle_input.zip` is ready;
      not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)